### PR TITLE
feature: improve sidebar collapse ux

### DIFF
--- a/packages/app/src/features/action-bar/hooks/use-flight-status.ts
+++ b/packages/app/src/features/action-bar/hooks/use-flight-status.ts
@@ -36,7 +36,6 @@ export default function useFlightStatus(): FlightStatus {
 		return { status: 'pending' };
 	}, [
 		currentFlight?.flightId,
-		currentFlight?.finish,
 		currentFlight?.flighting,
 		currentFlight?.lastUpdate,
 	]);

--- a/packages/app/src/features/project-pane/components/molecules/FolderItem.tsx
+++ b/packages/app/src/features/project-pane/components/molecules/FolderItem.tsx
@@ -5,6 +5,8 @@ import { checkShortcut } from '@beak/app/lib/keyboard-shortcuts';
 import { projectPanePreferenceSetCollapse } from '@beak/app/store/preferences/actions';
 import { TypedObject } from '@beak/common/helpers/typescript';
 import { FolderNode } from '@beak/common/types/beak-project';
+import { faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import styled from 'styled-components';
 
 import actions from '../../../../store/project/actions';
@@ -96,7 +98,9 @@ const FolderItem: React.FunctionComponent<FolderItemProps> = props => {
 					dispatch(projectPanePreferenceSetCollapse({ key: props.id, collapsed: !collapsed }));
 				}}
 			>
-				<Chevron expanded={!collapsed} />
+				<Chevron $collapsed={collapsed}>
+					<FontAwesomeIcon icon={faChevronRight} />
+				</Chevron>
 				<Renamer node={node} parentRef={element}>
 					{node.name}
 				</Renamer>
@@ -126,8 +130,9 @@ const FolderItem: React.FunctionComponent<FolderItemProps> = props => {
 const Wrapper = styled.div<{ depth: number }>`
 	display: flex;
 	padding: 3px 0;
-	padding-left: ${props => (props.depth * 8) + 11}px;
+	padding-left: ${props => (props.depth * 8) + 7}px;
 	color: ${props => props.theme.ui.textMinor};
+	align-items: center;
 	cursor: pointer;
 	font-size: 13px;
 	line-height: 18px;
@@ -143,19 +148,20 @@ const Wrapper = styled.div<{ depth: number }>`
 	}
 `;
 
-const Chevron = styled.div<{ expanded: boolean }>`
+const Chevron = styled.div<{ $collapsed: boolean }>`
 	display: inline-block;
-	border-right: 1px solid ${props => props.theme.ui.textOnSurfaceBackground};
-	border-bottom: 1px solid ${props => props.theme.ui.textOnSurfaceBackground};
-	width: 5px;
-	height: 5px;
-	margin-top: 6px;
-	margin-right: 5px;
-	margin-left: -5px;
-	transform: rotate(${props => props.expanded ? '45deg' : '-45deg'});
-	transform-origin: 50%;
+	margin-right: 2px;
+	width: 10px;
 
-	margin-bottom: ${props => props.expanded ? '2px' : '1px'};
+	font-size: 9px;
+	line-height: 9px;
+	color: ${p => p.theme.ui.textMinor};
+
+	> svg {
+		transition: transform .2s ease;
+		transform-origin: center center;
+		transform: rotate(${p => p.$collapsed ? '0deg' : '90deg'});
+	}
 `;
 
 export default FolderItem;

--- a/packages/app/src/features/sidebar/components/SidebarPaneSection.tsx
+++ b/packages/app/src/features/sidebar/components/SidebarPaneSection.tsx
@@ -49,6 +49,8 @@ const SidebarPaneSection: React.FunctionComponent<SidebarPaneSectionProps> = pro
 		<React.Fragment>
 			<SectionHeader
 				actions={actions}
+				collapsed={uiCollapsed}
+				disableCollapse={disableCollapse}
 				onClick={setCollapsedProxy}
 			>
 				{title}

--- a/packages/app/src/features/sidebar/components/molecules/SectionHeader.tsx
+++ b/packages/app/src/features/sidebar/components/molecules/SectionHeader.tsx
@@ -1,21 +1,27 @@
 import React from 'react';
 import { showContextMenu } from '@beak/app/utils/context-menu';
-import { faEllipsisV } from '@fortawesome/free-solid-svg-icons';
+import { faChevronRight, faEllipsisV } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import type { MenuItemConstructorOptions } from 'electron';
 import styled from 'styled-components';
 
 interface SectionHeaderProps {
 	actions?: MenuItemConstructorOptions[];
+	collapsed?: boolean;
+	disableCollapse?: boolean;
 	onClick: () => void;
 }
 
 const SectionHeader: React.FunctionComponent<SectionHeaderProps> = props => {
-	const { actions, children, onClick } = props;
+	const { actions, children, collapsed, disableCollapse, onClick } = props;
 
 	return (
-		<Container onClick={onClick}>
+		<Container onClick={onClick} $disableCollapse={disableCollapse}>
 			<Header>
+				<CollapsedIndicator $collapsed={collapsed}>
+					<FontAwesomeIcon icon={faChevronRight} />
+				</CollapsedIndicator>
+
 				{children}
 			</Header>
 			{actions && actions.length > 0 && (
@@ -35,22 +41,40 @@ const SectionHeader: React.FunctionComponent<SectionHeaderProps> = props => {
 	);
 };
 
-const Container = styled.div`
+const Container = styled.div<{ $disableCollapse?: boolean }>`
 	display: flex;
 	justify-content: space-between;
+	align-items: center;
 	padding: 6px 5px;
 
 	text-transform: uppercase;
 	font-size: 11px;
 	font-weight: 600;
 
-	cursor: pointer;
+	cursor: ${p => p.$disableCollapse ? 'default' : 'pointer'};
 `;
 
 const Header = styled.div`
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	overflow: hidden;
+`;
+
+const CollapsedIndicator = styled.div<{ $collapsed?: boolean }>`
+	display: inline-block;
+	margin-right: 3px;
+	padding-left: 2px;
+	width: 10px;
+
+	font-size: 11px;
+	line-height: 11px;
+	color: ${p => p.theme.ui.textMinor};
+
+	> svg {
+		transition: transform .2s ease;
+		transform-origin: center center;
+		transform: rotate(${p => p.$collapsed ? '0deg' : '90deg'});
+	}
 `;
 
 const Actions = styled.div`

--- a/packages/app/src/features/sidebar/components/molecules/SectionHeader.tsx
+++ b/packages/app/src/features/sidebar/components/molecules/SectionHeader.tsx
@@ -66,8 +66,8 @@ const CollapsedIndicator = styled.div<{ $collapsed?: boolean }>`
 	padding-left: 2px;
 	width: 10px;
 
-	font-size: 11px;
-	line-height: 11px;
+	font-size: 9px;
+	line-height: 9px;
 	color: ${p => p.theme.ui.textMinor};
 
 	> svg {


### PR DESCRIPTION
Several improvements to the UX around collapsing sidebar items

- Visual indicator of sidebar section collapse state (animated chevron)
- Updated chevron style on folder items in the sidebar
- AnImaTiOns

<img width="355" alt="Screenshot 2022-04-14 at 06 38 16" src="https://user-images.githubusercontent.com/2768524/163320731-aff16e34-5a4d-405f-a89a-55dd8c52be66.png">
 