### PR TITLE
fix: variable pasting would lose payload data

### DIFF
--- a/packages/app/src/features/variable-input/components/VariableInput.tsx
+++ b/packages/app/src/features/variable-input/components/VariableInput.tsx
@@ -272,6 +272,8 @@ const VariableInput = React.forwardRef<HTMLElement, VariableInputProps>((props, 
 				return;
 			}
 
+			// TODO(afr): Detect if payload is corrected, if it is ignore and mark the
+			// entire realtime value as an anomaly
 			const purePayload = elem.dataset.payload;
 
 			reconciledParts.push({

--- a/packages/app/src/features/variable-input/utils/pasting.ts
+++ b/packages/app/src/features/variable-input/utils/pasting.ts
@@ -14,7 +14,7 @@ const allowedDivAttributes = new Set([
 const sanitizerOptions: IOptions = {
 	allowedTags: ['div', 'span'],
 	allowedAttributes: {
-		div: Array.from(requiredDivAttributes),
+		div: Array.from(allowedDivAttributes),
 		span: [],
 	},
 	exclusiveFilter: frame => {


### PR DESCRIPTION
Very stupid oversight, but the pasting of a realtime value would lose some of the context of the original value.