### PR TITLE
feat(beak): media response previews

### DIFF
--- a/packages/app/src/features/response-pane/components/molecules/PrettyRenderSelection.tsx
+++ b/packages/app/src/features/response-pane/components/molecules/PrettyRenderSelection.tsx
@@ -29,7 +29,7 @@ const PrettyRenderSelection: React.FC<React.PropsWithChildren<PrettyRenderSelect
 				</optgroup>
 				<optgroup label={'Media'}>
 					<option value={'image'}>{'Image'}</option>
-					<option disabled>{'Video'}</option>
+					<option value={'video'}>{'Video'}</option>
 				</optgroup>
 				<optgroup label={'Other'}>
 					<option disabled>{'Web'}</option>

--- a/packages/app/src/features/response-pane/components/molecules/PrettyRenderSelection.tsx
+++ b/packages/app/src/features/response-pane/components/molecules/PrettyRenderSelection.tsx
@@ -28,7 +28,7 @@ const PrettyRenderSelection: React.FC<React.PropsWithChildren<PrettyRenderSelect
 					<option value={'css'}>{'CSS'}</option>
 				</optgroup>
 				<optgroup label={'Media'}>
-					<option disabled>{'Image'}</option>
+					<option value={'image'}>{'Image'}</option>
 					<option disabled>{'Video'}</option>
 				</optgroup>
 				<optgroup label={'Other'}>

--- a/packages/app/src/features/response-pane/components/organisms/PrettyViewer.tsx
+++ b/packages/app/src/features/response-pane/components/organisms/PrettyViewer.tsx
@@ -165,6 +165,16 @@ function renderFormat(language: string | null, contentType: string | null, body:
 			return <Image $imageBlob={blob} />;
 		}
 
+		case 'video': {
+			const blob = URL.createObjectURL(new Blob([body], { type: contentType ?? 'video/mp4' }));
+
+			return (
+				<Video controls autoPlay>
+					<source src={blob} />
+				</Video>
+			);
+		}
+
 		case null:
 		default: {
 			const text = new TextDecoder().decode(body);
@@ -203,6 +213,11 @@ const Image = styled.div<{ $imageBlob: string }>`
 	background-position: center;
 	background-size: contain;
 	background-repeat: no-repeat;
+	height: 100%;
+`;
+
+const Video = styled.video`
+	width: 100%;
 	height: 100%;
 `;
 

--- a/packages/app/src/features/response-pane/components/organisms/PrettyViewer.tsx
+++ b/packages/app/src/features/response-pane/components/organisms/PrettyViewer.tsx
@@ -159,6 +159,12 @@ function renderFormat(language: string | null, contentType: string | null, body:
 			);
 		}
 
+		case 'image': {
+			const blob = URL.createObjectURL(new Blob([body], { type: contentType ?? 'image/jpeg' }));
+
+			return <Image $imageBlob={blob} />;
+		}
+
 		case null:
 		default: {
 			const text = new TextDecoder().decode(body);
@@ -190,6 +196,14 @@ function tryFormatXml(xml: string) {
 
 const Container = styled.div`
 	height: calc(100% - 35px);
+`;
+
+const Image = styled.div<{ $imageBlob: string }>`
+	background-image: url(${p => p.$imageBlob});
+	background-position: center;
+	background-size: contain;
+	background-repeat: no-repeat;
+	height: 100%;
 `;
 
 export default React.memo(

--- a/packages/app/src/features/response-pane/components/organisms/PrettyViewer.tsx
+++ b/packages/app/src/features/response-pane/components/organisms/PrettyViewer.tsx
@@ -24,7 +24,7 @@ const PrettyViewer: React.FC<React.PropsWithChildren<PrettyViewerProps>> = ({ fl
 	const requestId = flight.requestId;
 	const preferences = useAppSelector(s => s.global.preferences.requests[requestId].response.pretty[mode]);
 	const [eligibility, body] = useFlightBodyInfo(flight, mode);
-	const detectedFormat = useDetectedFlightFormat(flight, mode);
+	const [contentType, detectedFormat] = useDetectedFlightFormat(flight, mode);
 	const selectedLanguage = preferences.language ?? detectedFormat;
 
 	if (eligibility !== 'eligible')
@@ -40,13 +40,13 @@ const PrettyViewer: React.FC<React.PropsWithChildren<PrettyViewerProps>> = ({ fl
 					language: lang,
 				}))}
 			/>
-			{renderFormat(selectedLanguage, body)}
+			{renderFormat(selectedLanguage, contentType, body)}
 		</Container>
 	);
 };
 
-function renderFormat(detectedFormat: string | null, body: Uint8Array) {
-	switch (detectedFormat) {
+function renderFormat(language: string | null, contentType: string | null, body: Uint8Array) {
+	switch (language) {
 		case 'json': {
 			const json = new TextDecoder().decode(body);
 

--- a/packages/app/src/features/response-pane/hooks/use-detected-flight-format.ts
+++ b/packages/app/src/features/response-pane/hooks/use-detected-flight-format.ts
@@ -2,14 +2,20 @@ import { useMemo } from 'react';
 import { Flight } from '@beak/app/store/flight/types';
 import mime from 'mime-types';
 
-export default function useDetectedFlightFormat(flight: Flight, mode: 'request' | 'response') {
+export default function useDetectedFlightFormat(flight: Flight, mode: 'request' | 'response'): [string | null, string | null] {
 	return useMemo(() => {
 		const contentType = getContentType(flight, mode);
 
 		if (!contentType)
-			return null;
+			return [null, null];
 
-		return mime.extension(contentType) || null;
+		switch (true) {
+			case contentType.startsWith('image/'):
+				return [contentType, 'image'];
+
+			default:
+				return [contentType, mime.extension(contentType) || null];
+		}
 	}, [flight.flightId]);
 }
 


### PR DESCRIPTION
Added support for media response type previews.

- [x] Add support for passing content-type around
- [x] Added support for images
- [x] Added support for video