### PR TITLE
feat(beak): new current request in flight experience 

### DIFF
--- a/packages/app/src/features/action-bar/hooks/use-flight-status.ts
+++ b/packages/app/src/features/action-bar/hooks/use-flight-status.ts
@@ -13,24 +13,23 @@ interface CompleteFlightStatus {
 type FlightStatus = PendingFlightStatus | ActiveFlightStatus | FailedFlightStatus | CompleteFlightStatus;
 
 export default function useFlightStatus(): FlightStatus {
-	const currentFlight = useAppSelector(s => s.global.flight.currentFlight);
+	const { currentFlight, latestFlight } = useAppSelector(s => s.global.flight);
 
 	return useMemo((): FlightStatus => {
-		if (!currentFlight)
-			return { status: 'pending' };
-
-		if (currentFlight.flighting)
+		if (currentFlight && currentFlight.flighting)
 			return { status: 'active', flightId: currentFlight.flightId };
 
-		if (currentFlight.error)
-			return { status: 'failed' };
+		if (latestFlight) {
+			if (latestFlight.error)
+				return { status: 'failed' };
 
-		if (currentFlight.response) {
-			return {
-				status: 'complete',
-				flightId: currentFlight.flightId,
-				httpStatus: currentFlight.response.status,
-			};
+			if (latestFlight.response) {
+				return {
+					status: 'complete',
+					flightId: latestFlight.flightId,
+					httpStatus: latestFlight.response.status,
+				};
+			}
 		}
 
 		return { status: 'pending' };
@@ -38,5 +37,8 @@ export default function useFlightStatus(): FlightStatus {
 		currentFlight?.flightId,
 		currentFlight?.flighting,
 		currentFlight?.lastUpdate,
+		latestFlight?.flightId,
+		latestFlight?.flighting,
+		latestFlight?.lastUpdate,
 	]);
 }

--- a/packages/app/src/features/response-pane/components/ResponsePane.tsx
+++ b/packages/app/src/features/response-pane/components/ResponsePane.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PendingSlash from '@beak/app/components/molecules/PendingSplash';
 import { useAppSelector } from '@beak/app/store/redux';
 import styled from 'styled-components';
@@ -10,9 +10,12 @@ const ResponsePane: React.FC<React.PropsWithChildren<unknown>> = () => {
 	const { tree } = useAppSelector(s => s.global.project);
 	const selectedTab = useAppSelector(s => s.features.tabs.selectedTab);
 	const flightHistories = useAppSelector(s => s.global.flight.flightHistory);
-	const selectedNode = tree![selectedTab || 'non_existent'];
+	const currentFlight = useAppSelector(s => s.global.flight.currentFlight);
+	const selectedNode = tree![selectedTab!];
+	const flightHistory = flightHistories[selectedTab!];
+	const selectedFlight = flightHistory?.history[flightHistory?.selected!];
 
-	if (!selectedTab) {
+	if (!selectedNode) {
 		return (
 			<Container>
 				<PendingSlash />
@@ -20,15 +23,13 @@ const ResponsePane: React.FC<React.PropsWithChildren<unknown>> = () => {
 		);
 	}
 
-	if (selectedTab && !selectedNode) {
+	if (currentFlight && currentFlight.requestId === selectedNode.id) {
 		return (
 			<Container>
-				<span>{'id does not exist'}</span>
+				{'doing!'}
 			</Container>
 		);
 	}
-
-	const flightHistory = flightHistories[selectedTab];
 
 	if (!flightHistory) {
 		return (
@@ -38,12 +39,10 @@ const ResponsePane: React.FC<React.PropsWithChildren<unknown>> = () => {
 		);
 	}
 
-	const selectedFlight = flightHistory.history[flightHistory.selected!];
-
 	if (!selectedFlight) {
 		return (
 			<Container>
-				<span>{'selected flight id does not exist'}</span>
+				<PendingSlash />
 			</Container>
 		);
 	}

--- a/packages/app/src/features/response-pane/components/ResponsePane.tsx
+++ b/packages/app/src/features/response-pane/components/ResponsePane.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import PendingSlash from '@beak/app/components/molecules/PendingSplash';
 import { useAppSelector } from '@beak/app/store/redux';
 import styled from 'styled-components';
 
+import FlightInProgress from './molecules/FlightInProgress';
 import Header from './molecules/Header';
 import Inspector from './organisms/Inspector';
 
@@ -14,48 +15,25 @@ const ResponsePane: React.FC<React.PropsWithChildren<unknown>> = () => {
 	const selectedNode = tree![selectedTab!];
 	const flightHistory = flightHistories[selectedTab!];
 	const selectedFlight = flightHistory?.history[flightHistory?.selected!];
-
-	if (!selectedNode) {
-		return (
-			<Container>
-				<PendingSlash />
-			</Container>
-		);
-	}
-
-	if (currentFlight && currentFlight.requestId === selectedNode.id) {
-		return (
-			<Container>
-				{'doing!'}
-			</Container>
-		);
-	}
-
-	if (!flightHistory) {
-		return (
-			<Container>
-				<PendingSlash />
-			</Container>
-		);
-	}
-
-	if (!selectedFlight) {
-		return (
-			<Container>
-				<PendingSlash />
-			</Container>
-		);
-	}
+	const pending = !selectedNode || !flightHistory || !selectedFlight;
 
 	return (
 		<Container>
-			<Header selectedFlight={selectedFlight} />
-			<Inspector flight={selectedFlight} />
+			{pending && <PendingSlash />}
+			{!pending && (
+				<React.Fragment>
+					<Header selectedFlight={selectedFlight} />
+					<Inspector flight={selectedFlight} />
+				</React.Fragment>
+			)}
+
+			<FlightInProgress requestId={selectedTab!} currentFlight={currentFlight} />
 		</Container>
 	);
 };
 
 const Container = styled.div`
+	position: relative;
 	display: flex;
 	flex-direction: column;
 	background-color: ${props => props.theme.ui.surface};

--- a/packages/app/src/features/response-pane/components/molecules/FlightInProgress.tsx
+++ b/packages/app/src/features/response-pane/components/molecules/FlightInProgress.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { FlightInProgress as FlightInProgressType } from '@beak/app/store/flight/types';
+import styled, { keyframes } from 'styled-components';
+
+const pulseRing = keyframes`
+	0% { transform: scale(.33); }
+	80%, 100% { opacity: 0; }
+`;
+
+interface FlightInProgressProps {
+	requestId: string;
+	currentFlight: FlightInProgressType | undefined;
+}
+
+const FlightInProgress: React.FC<FlightInProgressProps> = ({ currentFlight, requestId }) => {
+	const shown = Boolean(currentFlight && currentFlight.requestId === requestId);
+
+	return (
+		// <Container $shown={Boolean(currentFlight)}>
+		<Container $shown={shown}>
+			<PulseOrb />
+		</Container>
+	);
+};
+
+const Container = styled.div<{ $shown: boolean }>`
+	position: absolute;
+	pointer-events: none;
+	display: flex;
+	top: 0; bottom: 0; left: 0; right: 0;
+	align-items: center; justify-content: center;
+	background: ${p => p.theme.ui.background};
+	text-align: center;
+	transition: opacity .2s ease-out;
+	opacity: 0;
+
+	${p => p.$shown && 'opacity: 1;'}
+`;
+
+const PulseOrb = styled.div`
+	width: 50px; height: 50px;
+
+	&:before {
+		content: '';
+		position: relative;
+		display: block;
+		width: 250px; height: 250px;
+		box-sizing: border-box;
+		margin-left: -100px;
+		margin-top: -100px;
+		border-radius: 100%;
+		background-color: ${p => p.theme.ui.primaryFill};
+		animation: ${pulseRing} 1.25s cubic-bezier(0.215, 0.61, 0.355, 1) infinite;
+	}
+	&:after {
+		content: '';
+		display: block;
+		position: relative;
+		background-size: 45px;
+		background-position: center;
+		background-repeat: no-repeat;
+		background-image: url('./images/logo.svg');
+		opacity: .8;
+		margin-top: -150px;
+		width: 50px; height: 50px;
+	}
+`;
+
+export default FlightInProgress;

--- a/packages/app/src/store/flight/reducers.ts
+++ b/packages/app/src/store/flight/reducers.ts
@@ -72,6 +72,9 @@ const flightReducer = createReducer(initialState, builder => {
 				binaryStoreKey,
 				timing: state.currentFlight!.timing,
 			};
+
+			state.latestFlight = state.currentFlight;
+			state.currentFlight = void 0;
 		})
 		.addCase(actions.flightFailure, (state, action) => {
 			const { flightId, requestId, error } = action.payload;

--- a/packages/app/src/store/flight/types.ts
+++ b/packages/app/src/store/flight/types.ts
@@ -16,6 +16,7 @@ export const ActionTypes = {
 
 export interface State {
 	currentFlight?: FlightInProgress;
+	latestFlight?: FlightInProgress;
 	flightHistory: Record<string, FlightHistory>;
 	blackBox: Record<string, boolean>;
 }


### PR DESCRIPTION
It's hard to tell when a response has happened when looking at the response view, this should will make it clearer to the user.

- [x] Add `latestFlight` to live next to `currentFlight`
- [x] Add some UI to show the flight is in progress (with progress bar for big boy requests?)