### PR TITLE
fix(beak): improve behaviour around realtime values

### DIFF
--- a/packages/app/src/features/realtime-value-editor/components/RealtimeValueEditor.tsx
+++ b/packages/app/src/features/realtime-value-editor/components/RealtimeValueEditor.tsx
@@ -100,13 +100,13 @@ const RealtimeValueEditor: React.FC<React.PropsWithChildren<RealtimeValueEditorP
 		if (!editorContext)
 			return;
 
-		setEditorContext({
-			...editorContext,
+		setEditorContext(editorCtx => ({
+			...editorCtx!,
 			state: {
-				...editorContext.state,
+				...editorCtx!.state,
 				...delta,
 			},
-		});
+		}));
 	}
 
 	function close(item: any | null) {
@@ -137,7 +137,7 @@ const RealtimeValueEditor: React.FC<React.PropsWithChildren<RealtimeValueEditorP
 					switch (section.type) {
 						case 'value_parts_input':
 							return (
-								<FormGroup key={`${stateBinding}`}>
+								<FormGroup key={stateBinding}>
 									{section.label && <Label>{section.label}</Label>}
 									<VariableInput
 										ref={i => trySetInitialRef(first, i, initialInputRef)}
@@ -151,7 +151,7 @@ const RealtimeValueEditor: React.FC<React.PropsWithChildren<RealtimeValueEditorP
 
 						case 'string_input':
 							return (
-								<FormGroup key={`${stateBinding}`}>
+								<FormGroup key={stateBinding}>
 									{section.label && <Label>{section.label}</Label>}
 									<Input
 										ref={i => trySetInitialRef(first, i, initialInputRef)}
@@ -167,7 +167,7 @@ const RealtimeValueEditor: React.FC<React.PropsWithChildren<RealtimeValueEditorP
 
 						case 'checkbox_input':
 							return (
-								<FormGroup key={`${stateBinding}`}>
+								<FormGroup key={stateBinding}>
 									{section.label && <Label>{section.label}</Label>}
 									<Input
 										ref={i => trySetInitialRef(first, i, initialInputRef)}
@@ -184,7 +184,7 @@ const RealtimeValueEditor: React.FC<React.PropsWithChildren<RealtimeValueEditorP
 
 						case 'number_input':
 							return (
-								<FormGroup key={`${stateBinding}`}>
+								<FormGroup key={stateBinding}>
 									{section.label && <Label>{section.label}</Label>}
 									<Input
 										ref={i => trySetInitialRef(first, i, initialInputRef)}
@@ -200,7 +200,7 @@ const RealtimeValueEditor: React.FC<React.PropsWithChildren<RealtimeValueEditorP
 
 						case 'options_input':
 							return (
-								<FormGroup key={`${stateBinding}`}>
+								<FormGroup key={stateBinding}>
 									{section.label && <Label>{section.label}</Label>}
 									<Select
 										ref={i => trySetInitialRef(first, i, initialInputRef)}
@@ -217,7 +217,7 @@ const RealtimeValueEditor: React.FC<React.PropsWithChildren<RealtimeValueEditorP
 
 						case 'request_select_input':
 							return (
-								<FormGroup key={`${stateBinding}`}>
+								<FormGroup key={stateBinding}>
 									{section.label && <Label>{section.label}</Label>}
 									<Select
 										ref={i => trySetInitialRef(first, i, initialInputRef)}

--- a/packages/app/src/features/realtime-value-editor/components/RealtimeValueEditor.tsx
+++ b/packages/app/src/features/realtime-value-editor/components/RealtimeValueEditor.tsx
@@ -43,8 +43,13 @@ const RealtimeValueEditor: React.FC<React.PropsWithChildren<RealtimeValueEditorP
 	}, [Boolean(editorContext)]);
 
 	useEffect(() => {
-		if (!editorContext)
+		if (!editorContext) {
+			// If the editor context is reset, then we need to reset some more local state
+			setUiSections([]);
+			setPreview('');
+
 			return;
+		}
 
 		previewValue(context, editorContext.realtimeValue, editorContext.item, editorContext.state)
 			.then(setPreview);

--- a/packages/app/src/features/realtime-values/renderer.tsx
+++ b/packages/app/src/features/realtime-values/renderer.tsx
@@ -10,7 +10,7 @@ import { getVariableGroupItemName } from './values/variable-group-item';
 export default function renderValueParts(parts: ValueParts, variableGroups: VariableGroups) {
 	return renderToStaticMarkup(
 		<React.Fragment>
-			{parts.map((p, idx) => {
+			{(parts ?? []).map((p, idx) => {
 				if (typeof p === 'string')
 					return <span key={p}>{p}</span>;
 

--- a/packages/app/src/features/realtime-values/utils/response.ts
+++ b/packages/app/src/features/realtime-values/utils/response.ts
@@ -7,7 +7,7 @@ export function getLatestFlight(id: string, ctx: Context) {
 	if (!requestFlightHistory)
 		return null;
 
-	const latestFlight = TypedObject.values(requestFlightHistory.history)[0];
+	const latestFlight = TypedObject.values(requestFlightHistory.history).reverse()[0];
 
 	return latestFlight;
 }


### PR DESCRIPTION
- Add check to prevent a full application crash if value parts is null
- Fix state reset bug with the realtime value editor
- Fix two bugs with the response history realtime values