### PR TITLE
feat(beak): added marketing consent dialog

### DIFF
--- a/packages/common/src/types/nest.d.ts
+++ b/packages/common/src/types/nest.d.ts
@@ -64,6 +64,15 @@ export interface GetSubscriptionStatusResponse {
 	cancelledAt: string | null;
 }
 
+export interface GetMarketingConsentResponse {
+	level: 'none' | 'general';
+}
+
+export interface SetMarketingConsentRequest {
+	userId: string;
+	level: 'none' | 'general';
+}
+
 export interface GetUserRequest {
 	userId: string;
 }

--- a/packages/electron-host/src/lib/marketing-consent.ts
+++ b/packages/electron-host/src/lib/marketing-consent.ts
@@ -1,0 +1,50 @@
+import Squawk from '@beak/squawk';
+import { dialog } from 'electron';
+
+import logger from './logger';
+import nestClient from './nest-client';
+import persistentStore from './persistent-store';
+
+export async function attemptMarketingConsentScreen() {
+	const passedOnboarding = persistentStore.get('passedOnboarding');
+
+	if (!passedOnboarding)
+		return;
+
+	try {
+		await nestClient.getMarketingConsent();
+
+		// TODO(afr): Later on, ask again after x time if they select no
+
+		return;
+	} catch (error) {
+		const squawk = Squawk.coerce(error);
+
+		if (squawk.code !== 'awaiting_consent') {
+			logger.error('unknown error getting marketing consent', error);
+
+			return;
+		}
+	}
+
+	const { response } = await dialog.showMessageBox({
+		type: 'info',
+		title: 'Review marketing permissions',
+		message: 'Can we send you relevant emails about Beak? This will include new features, beta invites, and feedback.',
+		detail: `
+Beak is built for developers, by developers. We won't ever spam you or sell your data.
+`.trim(),
+		buttons: ['Not now', 'Sure', 'No thanks'],
+		cancelId: 0,
+		defaultId: 1,
+	});
+
+	if (response === 0)
+		return;
+
+	try {
+		await nestClient.setMarketingConsent(response === 1 ? 'general' : 'none');
+	} catch (error) {
+		logger.error('unknown error setting marketing consent', error);
+	}
+}

--- a/packages/electron-host/src/lib/nest-client.ts
+++ b/packages/electron-host/src/lib/nest-client.ts
@@ -1,5 +1,6 @@
 import {
 	AuthenticateUserResponse,
+	GetMarketingConsentResponse,
 	GetSubscriptionStatusResponse,
 	GetUserResponse,
 	NewsItem,
@@ -183,6 +184,29 @@ class NestClient {
 
 		return await this.rpc<GetSubscriptionStatusResponse>('2021-10-06/get_subscription_status', {
 			userId: auth.userId,
+		});
+	}
+
+	async getMarketingConsent() {
+		const auth = await this.getAuth();
+
+		if (!auth)
+			throw new Squawk('not_authenticated');
+
+		return await this.rpc<GetMarketingConsentResponse>('2020-12-14/get_marketing_consent', {
+			userId: auth.userId,
+		});
+	}
+
+	async setMarketingConsent(level: 'none' | 'general') {
+		const auth = await this.getAuth();
+
+		if (!auth)
+			throw new Squawk('not_authenticated');
+
+		return await this.rpc('2020-12-14/set_marketing_consent', {
+			userId: auth.userId,
+			level,
 		});
 	}
 

--- a/packages/electron-host/src/main.ts
+++ b/packages/electron-host/src/main.ts
@@ -6,6 +6,7 @@ import { autoUpdater } from 'electron-updater';
 
 import './ipc-layer';
 import arbiter from './lib/arbiter';
+import { attemptMarketingConsentScreen } from './lib/marketing-consent';
 import nestClient from './lib/nest-client';
 import persistentStore from './lib/persistent-store';
 import { tryOpenProjectFolder } from './lib/project';
@@ -109,6 +110,8 @@ async function createOrFocusDefaultWindow(initial = false) {
 
 	if (!auth)
 		return void createPortalWindow();
+
+	attemptMarketingConsentScreen();
 
 	if (initial && attemptWindowPresenceLoad())
 		return void 0;


### PR DESCRIPTION
Add's a dialog to ask a user for consent to email them about Beak tings.