### PR TITLE
fix: unblock web shell cold start + clear out CI build debt

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,15 @@
+# Default flags for `act` — run with `act` from repo root.
+#
+# - `--container-architecture linux/amd64` is required on Apple Silicon: act
+#   defaults to the host arch but most GitHub-action images only publish amd64.
+# - `macos-latest` is substituted with a heavy ubuntu image (`act-latest`).
+#   We can't actually run macOS in Docker, so platform-specific steps
+#   (electron-builder packaging .dmg/.pkg, codesigning) will diverge from the
+#   real CI. But lint, typecheck, the vite + esbuild builds, and electron-builder's
+#   "compute electron version" check all run before that — enough to iterate on.
+# - Secrets are read from `.secrets.act.local` (gitignored). See that file for
+#   the list of keys; dummy values are fine for any step that doesn't network out.
+
+--container-architecture linux/amd64
+-P macos-latest=catthehacker/ubuntu:act-latest
+--secret-file .secrets.act.local

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,8 @@ test-results/
 
 .playwright-cli/
 screenshots/
+
+# act (local GitHub Actions runner) — `.actrc` is committed (shared defaults),
+# `.secrets.act.local` is local-only.
+.secrets.act.local
+

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 <p align="center">
 	<img src="https://github.com/getbeak/beak/actions/workflows/beak-host.yml/badge.svg" alt="Beak host build badge" />
-	<img src="https://vercelbadge.vercel.app/api/getbeak/beak?style=flat" alt="Beak web build badge" />
 </p>
 
 <h2 style="border-bottom: none" align="center">Beak</h1>

--- a/apps-host/electron/electron-builder.json
+++ b/apps-host/electron/electron-builder.json
@@ -2,6 +2,7 @@
 	"appId": "app.getbeak.beak",
 	"productName": "Beak",
 	"copyright": "Copyright © 2022 Flamingo Corp Ltd",
+	"electronVersion": "37.10.3",
 	"extraMetadata": {
 		"name": "Beak",
 		"main": "main.js"

--- a/apps-host/electron/esbuild.main.config.ts
+++ b/apps-host/electron/esbuild.main.config.ts
@@ -1,6 +1,6 @@
 import { createRequire } from 'node:module';
 import path from 'node:path';
-import SentryCliModule from '@sentry/cli';
+import { SentryCli } from '@sentry/cli';
 import type { BuildOptions, PluginBuild } from 'esbuild';
 
 const require = createRequire(import.meta.url);
@@ -71,19 +71,13 @@ const sentrySourceMapsPlugin = {
 				return;
 			}
 
-			// biome-ignore lint/suspicious/noExplicitAny: Sentry CLI ships untyped CJS interop.
-			const SentryCliCtor = ((SentryCliModule as any).default ?? SentryCliModule) as new (
-				configFile: string | null,
-				options: Record<string, unknown>,
-				// biome-ignore lint/suspicious/noExplicitAny: see above
-			) => any;
-			const cli = new SentryCliCtor(null, {
+			const cli = new SentryCli(null, {
 				authToken: process.env.SENTRY_AUTH_TOKEN,
 				org: 'beak',
 				project: 'apps-host-electron',
 			});
 
-			await cli.releases.new(releaseIdentifier);
+			await cli.releases.new(releaseIdentifier, {});
 			await cli.releases.uploadSourceMaps(releaseIdentifier, {
 				include: ['./dist'],
 				urlPrefix: '~/',

--- a/apps-host/electron/src/ipc-layer/project-service.ts
+++ b/apps-host/electron/src/ipc-layer/project-service.ts
@@ -6,7 +6,6 @@ import { dialog, type IpcMainInvokeEvent, ipcMain } from 'electron';
 import getBeakHost from '../host';
 import { openProjectDialog, tryOpenProjectFolder } from '../host/project';
 import { closeWindow, createProjectMainWindow, tryCloseWelcomeWindow, windowStack } from '../window-management';
-import { getProjectFolder } from './utils';
 
 const service = new IpcProjectServiceMain(ipcMain);
 

--- a/apps-host/web/src/ipc/fs-service.ts
+++ b/apps-host/web/src/ipc/fs-service.ts
@@ -8,6 +8,7 @@ import {
 	type WriteJsonReq,
 	type WriteTextReq,
 } from '@beak/common/ipc/fs';
+import Squawk from '@beak/common/utils/squawk';
 
 import getBeakHost from '../host';
 import { fileOrFolderExists } from './fs-shared';
@@ -16,15 +17,29 @@ import { getCurrentProjectFolder } from './utils';
 
 const service = new IpcFsServiceMain(webIpcMain);
 
+// Memory-mode projects on the web don't have a `project.json` on OPFS yet —
+// `ensureWithinProject` throws `path_not_project` for them. Reads return safe
+// defaults so the renderer can still load preferences / discover that nothing
+// exists, and writes silently swallow because there's no disk identity to
+// persist to until the user runs "Save Project As…".
+function isMissingProjectError(error: unknown): boolean {
+	return error instanceof Squawk && error.code === 'path_not_project';
+}
+
 service.registerReadJson(async (_event, payload: ReadJsonReq) => {
 	const projectFolder = getCurrentProjectFolder();
 
 	if (!projectFolder) return '';
 
-	const filePath = await ensureWithinProject(projectFolder, payload.filePath);
-	const fileJson = await getBeakHost().p.node.fs.promises.readFile(filePath, 'utf8');
+	try {
+		const filePath = await ensureWithinProject(projectFolder, payload.filePath);
+		const fileJson = await getBeakHost().p.node.fs.promises.readFile(filePath, 'utf8');
 
-	return JSON.parse(fileJson);
+		return JSON.parse(fileJson);
+	} catch (error) {
+		if (isMissingProjectError(error)) return '';
+		throw error;
+	}
 });
 
 service.registerWriteJson(async (_event, payload: WriteJsonReq) => {
@@ -32,11 +47,20 @@ service.registerWriteJson(async (_event, payload: WriteJsonReq) => {
 
 	if (!projectFolder) return '';
 
-	const filePath = await ensureWithinProject(projectFolder, payload.filePath);
+	try {
+		const filePath = await ensureWithinProject(projectFolder, payload.filePath);
 
-	await ensureParentDirectoryExists(filePath);
+		await ensureParentDirectoryExists(filePath);
 
-	return await getBeakHost().p.node.fs.promises.writeFile(filePath, JSON.stringify(payload.content, null, '\t'), 'utf8');
+		return await getBeakHost().p.node.fs.promises.writeFile(
+			filePath,
+			JSON.stringify(payload.content, null, '\t'),
+			'utf8',
+		);
+	} catch (error) {
+		if (isMissingProjectError(error)) return '';
+		throw error;
+	}
 });
 
 service.registerReadText(async (_event, payload: ReadTextReq) => {
@@ -44,9 +68,14 @@ service.registerReadText(async (_event, payload: ReadTextReq) => {
 
 	if (!projectFolder) return '';
 
-	const filePath = await ensureWithinProject(projectFolder, payload.filePath);
+	try {
+		const filePath = await ensureWithinProject(projectFolder, payload.filePath);
 
-	return await getBeakHost().p.node.fs.promises.readFile(filePath, 'utf8');
+		return await getBeakHost().p.node.fs.promises.readFile(filePath, 'utf8');
+	} catch (error) {
+		if (isMissingProjectError(error)) return '';
+		throw error;
+	}
 });
 
 service.registerWriteText(async (_event, payload: WriteTextReq) => {
@@ -54,11 +83,16 @@ service.registerWriteText(async (_event, payload: WriteTextReq) => {
 
 	if (!projectFolder) return '';
 
-	const filePath = await ensureWithinProject(projectFolder, payload.filePath);
+	try {
+		const filePath = await ensureWithinProject(projectFolder, payload.filePath);
 
-	await ensureParentDirectoryExists(filePath);
+		await ensureParentDirectoryExists(filePath);
 
-	return await getBeakHost().p.node.fs.promises.writeFile(filePath, payload.content, 'utf8');
+		return await getBeakHost().p.node.fs.promises.writeFile(filePath, payload.content, 'utf8');
+	} catch (error) {
+		if (isMissingProjectError(error)) return '';
+		throw error;
+	}
 });
 
 service.registerPathExists(async (_event, payload: SimplePath) => {
@@ -66,9 +100,14 @@ service.registerPathExists(async (_event, payload: SimplePath) => {
 
 	if (!projectFolder) return false;
 
-	const filePath = await ensureWithinProject(projectFolder, payload.filePath);
+	try {
+		const filePath = await ensureWithinProject(projectFolder, payload.filePath);
 
-	return fileOrFolderExists(filePath);
+		return fileOrFolderExists(filePath);
+	} catch (error) {
+		if (isMissingProjectError(error)) return false;
+		throw error;
+	}
 });
 
 service.registerEnsureFile(async (_event, payload: SimplePath) => {
@@ -76,9 +115,14 @@ service.registerEnsureFile(async (_event, payload: SimplePath) => {
 
 	if (!projectFolder) return;
 
-	const filePath = await ensureWithinProject(projectFolder, payload.filePath);
+	try {
+		const filePath = await ensureWithinProject(projectFolder, payload.filePath);
 
-	await ensureParentDirectoryExists(filePath);
+		await ensureParentDirectoryExists(filePath);
+	} catch (error) {
+		if (isMissingProjectError(error)) return;
+		throw error;
+	}
 });
 
 service.registerEnsureDir(async (_event, payload: SimplePath) => {
@@ -86,9 +130,14 @@ service.registerEnsureDir(async (_event, payload: SimplePath) => {
 
 	if (!projectFolder) return;
 
-	const filePath = await ensureWithinProject(projectFolder, payload.filePath);
+	try {
+		const filePath = await ensureWithinProject(projectFolder, payload.filePath);
 
-	await ensureParentDirectoryExists(filePath);
+		await ensureParentDirectoryExists(filePath);
+	} catch (error) {
+		if (isMissingProjectError(error)) return;
+		throw error;
+	}
 });
 
 service.registerRemove(async (_event, payload: SimplePath) => {
@@ -96,11 +145,16 @@ service.registerRemove(async (_event, payload: SimplePath) => {
 
 	if (!projectFolder) return;
 
-	const filePath = await ensureWithinProject(projectFolder, payload.filePath);
+	try {
+		const filePath = await ensureWithinProject(projectFolder, payload.filePath);
 
-	// User-facing "delete" — match the electron handler's `shell.trashItem`
-	// semantics by recursing into folders and tolerating already-gone paths.
-	await getBeakHost().providers.node.fs.promises.rm(filePath, { recursive: true, force: true });
+		// User-facing "delete" — match the electron handler's `shell.trashItem`
+		// semantics by recursing into folders and tolerating already-gone paths.
+		await getBeakHost().providers.node.fs.promises.rm(filePath, { recursive: true, force: true });
+	} catch (error) {
+		if (isMissingProjectError(error)) return;
+		throw error;
+	}
 });
 
 service.registerMove(async (_event, payload: MoveReq) => {
@@ -108,10 +162,15 @@ service.registerMove(async (_event, payload: MoveReq) => {
 
 	if (!projectFolder) return;
 
-	const srcPath = await ensureWithinProject(projectFolder, payload.srcPath);
-	const dstPath = await ensureWithinProject(projectFolder, payload.dstPath);
+	try {
+		const srcPath = await ensureWithinProject(projectFolder, payload.srcPath);
+		const dstPath = await ensureWithinProject(projectFolder, payload.dstPath);
 
-	await getBeakHost().p.node.fs.promises.rename(srcPath, dstPath);
+		await getBeakHost().p.node.fs.promises.rename(srcPath, dstPath);
+	} catch (error) {
+		if (isMissingProjectError(error)) return;
+		throw error;
+	}
 });
 
 service.registerReadDir(async (_event, payload: ReadDirReq) => {
@@ -119,7 +178,13 @@ service.registerReadDir(async (_event, payload: ReadDirReq) => {
 
 	if (!projectFolder) return [];
 
-	const filePath = await ensureWithinProject(projectFolder, payload.filePath);
+	let filePath: string;
+	try {
+		filePath = await ensureWithinProject(projectFolder, payload.filePath);
+	} catch (error) {
+		if (isMissingProjectError(error)) return [];
+		throw error;
+	}
 	// lightning-fs partially supports the node fs.promises.readdir API but
 	// its `withFileTypes` handling returns `[name, stat]` tuples in some
 	// versions, which then break the downstream `path.join(dir, name)` call

--- a/apps-host/web/src/ipc/utils.ts
+++ b/apps-host/web/src/ipc/utils.ts
@@ -1,17 +1,19 @@
+import { getActiveProjectIdHint } from '@beak/ui/services/web-bridge';
+
 import { getRootMode } from '../host';
 
 const projectIdRegex = /\/project\/(.+)/g;
 
-export function getCurrentProjectId() {
+export function getCurrentProjectId(): string | null {
 	const { pathname } = window.location;
 
 	const matches = [...pathname.matchAll(projectIdRegex)][0];
 
-	const projectId = matches[1];
+	if (matches?.[1]) return matches[1];
 
-	if (!projectId) return null;
-
-	return projectId;
+	// Memory-mode projects don't navigate the URL; the renderer leaves a
+	// hint in sessionStorage so we can still scope per-project work.
+	return getActiveProjectIdHint();
 }
 
 /**

--- a/apps-host/web/vite.config.js
+++ b/apps-host/web/vite.config.js
@@ -18,7 +18,6 @@ const versionRelease = Boolean(process.env.VERSION_RELEASE);
 const versionIdentifier = packageJson.version;
 const commitIdentifier = process.env.COMMIT_IDENTIFIER;
 const releaseIdentifier = versionRelease ? `beak-app@${versionIdentifier}` : commitIdentifier;
-const sourcePathInDev = environment === 'development' ? 'src' : '';
 
 /**
  * @type {import('vite').UserConfig}
@@ -34,7 +33,7 @@ export default {
 		alias: {
 			'@beak/apps-host-web': path.join(__dirname, './src'),
 
-			'@beak/ui': path.join(__dirname, `../../packages/ui/${sourcePathInDev}`),
+			'@beak/ui': path.join(__dirname, '../../packages/ui/src'),
 			'@beak/common': path.join(__dirname, '../../packages/common/src'),
 			'@beak/runtime-shared': path.join(__dirname, '../../packages/runtime-shared/src'),
 			'@beak/state': path.join(__dirname, '../../packages/state/src'),

--- a/apps-web/share/src/components/atoms/Buttons.tsx
+++ b/apps-web/share/src/components/atoms/Buttons.tsx
@@ -1,4 +1,4 @@
-import { Box, type BoxProps, chakra } from '@chakra-ui/react';
+import { type BoxProps, chakra } from '@chakra-ui/react';
 import * as React from 'react';
 
 interface CtaButtonProps extends Omit<BoxProps, 'as'> {

--- a/biome.json
+++ b/biome.json
@@ -39,7 +39,8 @@
 			"bracketSpacing": true,
 			"arrowParentheses": "asNeeded",
 			"quoteProperties": "asNeeded"
-		}
+		},
+		"jsxRuntime": "reactClassic"
 	},
 	"json": {
 		"formatter": {

--- a/packages/state/src/project-tree/index.ts
+++ b/packages/state/src/project-tree/index.ts
@@ -62,7 +62,8 @@ export function findDescendants(tree: Tree, rootId: string, type?: Nodes['type']
 	const childrenByParent: Record<string, Nodes[]> = {};
 	for (const node of Object.values(tree)) {
 		const key = node.parent ?? '';
-		(childrenByParent[key] ??= []).push(node);
+		if (!childrenByParent[key]) childrenByParent[key] = [];
+		childrenByParent[key].push(node);
 	}
 	const out: Nodes[] = [];
 	const stack: string[] = [rootId];

--- a/packages/ui/src/components/molecules/BrowserStorageBanner.tsx
+++ b/packages/ui/src/components/molecules/BrowserStorageBanner.tsx
@@ -1,7 +1,7 @@
 import { exportProjectToLocalFolder } from '@beak/ui/features/welcome/lib/export-to-local-folder';
 import { ipcBeakHubService } from '@beak/ui/lib/ipc';
 import { useAppSelector } from '@beak/ui/store/redux';
-import { Box, Button, Flex, Text } from '@chakra-ui/react';
+import { Button, Flex, Text } from '@chakra-ui/react';
 import { motion } from 'framer-motion';
 import { Cloud } from 'lucide-react';
 import * as React from 'react';

--- a/packages/ui/src/components/molecules/UntitledBanner.tsx
+++ b/packages/ui/src/components/molecules/UntitledBanner.tsx
@@ -1,5 +1,5 @@
 import { useAppSelector } from '@beak/ui/store/redux';
-import { Box, Button, Flex, Text } from '@chakra-ui/react';
+import { Button, Flex, Text } from '@chakra-ui/react';
 import { motion } from 'framer-motion';
 import { FileWarning } from 'lucide-react';
 import * as React from 'react';

--- a/packages/ui/src/containers/ProjectMain.tsx
+++ b/packages/ui/src/containers/ProjectMain.tsx
@@ -30,8 +30,6 @@ import { useProjectBootstrap } from '../hooks/use-project-bootstrap';
 import { useProjectLoading } from '../hooks/use-project-loading';
 import { useUnsavedChangesGuard } from '../hooks/use-unsaved-changes-guard';
 
-const embedded = Boolean(window.embeddedIndicator);
-
 const ProjectMain: React.FC = () => {
 	const [title, setTitle] = useState('Loading… - Beak');
 	const [setup, setSetup] = useState(false);

--- a/packages/ui/src/entrypoints/web.tsx
+++ b/packages/ui/src/entrypoints/web.tsx
@@ -3,8 +3,9 @@ import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 
 import AgentPairReturn from '../containers/AgentPairReturn';
 import WebProjectMain from '../containers/WebProjectMain';
+import { setActiveProjectIdHint } from '../services/web-bridge';
 import { discoverAgentRequested } from '../store/effects/agent';
-import { useAppDispatch } from '../store/redux';
+import { useAppDispatch, useAppSelector } from '../store/redux';
 
 // `/` mounts the empty workbench (welcome tab, no project bootstrap).
 // `/project/:projectId` mounts a bound project — same shell, full bootstrap.
@@ -23,9 +24,17 @@ const router = createBrowserRouter([
 
 export const WebEntrypoint: React.FC = () => {
 	const dispatch = useAppDispatch();
+	const activeProjectId = useAppSelector(state => state.global.project.id ?? null);
+
 	useEffect(() => {
 		dispatch(discoverAgentRequested());
 	}, [dispatch]);
+
+	// Reflect the active project id into sessionStorage so the web host's
+	// IPC handlers can find it when the URL stays at `/` (memory mode).
+	useEffect(() => {
+		setActiveProjectIdHint(activeProjectId);
+	}, [activeProjectId]);
 
 	return <RouterProvider router={router} />;
 };

--- a/packages/ui/src/features/omni-bar/components/OmniRow.tsx
+++ b/packages/ui/src/features/omni-bar/components/OmniRow.tsx
@@ -1,8 +1,7 @@
 import { Box, chakra, Flex } from '@chakra-ui/react';
 import { motion } from 'framer-motion';
 import { CornerDownLeft } from 'lucide-react';
-import * as React from 'react';
-import { forwardRef } from 'react';
+import React, { forwardRef } from 'react';
 
 import { CATEGORY_META } from '../lib/categories';
 import type { OmniItem } from '../lib/types';

--- a/packages/ui/src/features/project-pane/components/organisms/Workflows.tsx
+++ b/packages/ui/src/features/project-pane/components/organisms/Workflows.tsx
@@ -57,6 +57,13 @@ const Workflows: React.FC = () => {
 		return ranked.map(r => workflows[r.id]).filter((wf): wf is NonNullable<typeof wf> => Boolean(wf));
 	}, [filter, workflows]);
 
+	// Tag chip bar above the row list. Click a chip to populate the filter
+	// input with the matching #tag prefix — discoverability for the new
+	// tag-filter path. Hidden until the project has at least a couple of
+	// tagged workflows so the chrome doesn't dominate small projects. Hoisted
+	// above the empty-state early-return so hook order stays stable.
+	const allTags = React.useMemo(() => extractAllTags(workflows), [workflows]);
+
 	if (total === 0) {
 		return (
 			<Box px='3' py='2' fontSize='11px' color='fg.subtle' lineHeight='1.45'>
@@ -66,11 +73,6 @@ const Workflows: React.FC = () => {
 	}
 
 	const showFilter = total >= 3;
-	// Tag chip bar above the row list. Click a chip to populate the filter
-	// input with the matching #tag prefix — discoverability for the new
-	// tag-filter path. Hidden until the project has at least a couple of
-	// tagged workflows so the chrome doesn't dominate small projects.
-	const allTags = React.useMemo(() => extractAllTags(workflows), [workflows]);
 	const activeTag = filter.trim().startsWith('#') ? filter.trim().slice(1).trim().toLowerCase() : '';
 
 	return (

--- a/packages/ui/src/features/source-schemas/components/SourceSchemaDialog.tsx
+++ b/packages/ui/src/features/source-schemas/components/SourceSchemaDialog.tsx
@@ -81,7 +81,8 @@ function validateFolderName(raw: string): string | null {
 	if (name.includes('/') || name.includes('\\')) return 'No slashes — pick a single folder name.';
 	// Reserved on Windows + characters that need shell quoting on POSIX. Banning
 	// them across the board keeps projects portable without per-platform
-	// guesswork.
+	// guesswork. The control-char range \x00-\x1f is intentional here.
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: intentional — validating against control chars
 	if (/[<>:"|?*\x00-\x1f]/.test(name)) return 'Use plain characters — no control characters, <, >, :, ", |, ?, or *.';
 	if (name === '.' || name === '..') return '“.” and “..” aren’t valid folder names.';
 	if (name.startsWith('.') || name.startsWith('-')) return 'Don’t start with a dot or dash.';
@@ -99,28 +100,39 @@ function validateFolderName(raw: string): string | null {
  * monospace chip beneath the form, replacing the previous two-pane layout
  * whose sidebar made the dialog feel busy without paying its weight.
  */
-const SourceSchemaDialog: React.FC<SourceSchemaDialogProps> = ({
+/**
+ * Dispatcher: OpenAPI renders its own dialog (which owns its hooks); the gRPC
+ * and GraphQL variants share `GrpcOrGraphqlSourceSchemaDialog` (which owns its
+ * hooks). Keeping the dispatch hook-free is mandatory — Rules of Hooks forbids
+ * a conditional early-return before useState calls.
+ */
+const SourceSchemaDialog: React.FC<SourceSchemaDialogProps> = props => {
+	if (props.sourceSchemaKind === 'openapi')
+		return (
+			<OpenApiSourceSchemaDialog
+				mode={props.mode}
+				initialOpenApiSource={props.initialOpenApiSource}
+				lastSyncedAt={props.lastSyncedAt}
+				onSyncNow={props.onSyncNow}
+				onClose={props.onClose}
+			/>
+		);
+	return <GrpcOrGraphqlSourceSchemaDialog {...props} sourceSchemaKind={props.sourceSchemaKind} />;
+};
+
+interface GrpcOrGraphqlSourceSchemaDialogProps extends Omit<SourceSchemaDialogProps, 'sourceSchemaKind'> {
+	sourceSchemaKind: Exclude<SourceSchemaDialogProps['sourceSchemaKind'], 'openapi'>;
+}
+
+const GrpcOrGraphqlSourceSchemaDialog: React.FC<GrpcOrGraphqlSourceSchemaDialogProps> = ({
 	sourceSchemaKind,
 	mode,
 	initialEndpoint,
 	initialDescriptor,
-	initialOpenApiSource,
 	lastSyncedAt,
-	onSyncNow,
 	onOpenIntrospection,
 	onClose,
 }) => {
-	if (sourceSchemaKind === 'openapi')
-		return (
-			<OpenApiSourceSchemaDialog
-				mode={mode}
-				initialOpenApiSource={initialOpenApiSource}
-				lastSyncedAt={lastSyncedAt}
-				onSyncNow={onSyncNow}
-				onClose={onClose}
-			/>
-		);
-
 	const config = SOURCE_SCHEMA_CONFIG[sourceSchemaKind];
 	const isCreate = mode.kind === 'create';
 	const isGrpc = sourceSchemaKind === 'grpc';

--- a/packages/ui/src/features/tabs/components/TabView.tsx
+++ b/packages/ui/src/features/tabs/components/TabView.tsx
@@ -102,7 +102,7 @@ const TabView: React.FC<TabViewProps> = ({ selectedTab, tabs, rightSlot }) => {
 			{ root, threshold: [0, 0.92, 1] },
 		);
 
-		children.forEach(el => observer.observe(el));
+		for (const el of children) observer.observe(el);
 		return () => observer.disconnect();
 	}, [sortedTabs]);
 

--- a/packages/ui/src/features/tabs/components/molecules/RequestTab.tsx
+++ b/packages/ui/src/features/tabs/components/molecules/RequestTab.tsx
@@ -30,17 +30,19 @@ const RequestTab: React.FC<React.PropsWithChildren<RequestTabProps>> = ({ tab })
 		return parent?.type === 'folder' ? parent.name : undefined;
 	});
 	const [target, setTarget] = useState<HTMLElement>();
+	// Hooks must precede the early-return; pass `node?.id` defensively so the
+	// hook order stays stable when `node` is briefly missing (deadness is
+	// handled one level up in TabView via `selectTabAlive`).
+	const nodeId = node && node.type === 'request' ? node.id : null;
+	const isDirty = useAppSelector(s => (nodeId ? Boolean(s.global.project.linkedDirty[nodeId]) : false));
+	const isStale = useAppSelector(s => (nodeId ? Boolean(s.global.project.linkedStale[nodeId]) : false));
 
-	// Deadness is handled one level up in TabView via `selectTabAlive`; if we
-	// got rendered, the underlying node is still around.
 	if (!node || node.type !== 'request') return null;
 
 	const verb = node.mode === 'valid' ? node.info.verb : 'get';
 	const color = verbToColor(verb);
 	const isIntrospection = node.mode === 'valid' && node.info.introspection === true;
 	const isLinked = node.mode === 'valid' && provenance.isLinked(node.info);
-	const isDirty = useAppSelector(s => Boolean(s.global.project.linkedDirty[node.id]));
-	const isStale = useAppSelector(s => Boolean(s.global.project.linkedStale[node.id]));
 	const VerbIcon = isLinked ? Link2 : ArrowUpRight;
 	const verbIconColor = isStale ? 'var(--beak-colors-accent-alert)' : color;
 	const verbIconTitle = isLinked

--- a/packages/ui/src/services/agent/pairing.ts
+++ b/packages/ui/src/services/agent/pairing.ts
@@ -8,6 +8,11 @@ import { newPkcePair, newState } from './crypto';
 // it's per-tab, and the agent's return URL lands in a fresh tab with an
 // empty sessionStorage. `localStorage` is shared across same-origin tabs,
 // and the `state` lookup means a concurrent second pairing can't collide.
+//
+// All `localStorage` access is guarded — it can throw in private-mode
+// browsers, when storage is disabled by the user, or when the quota is
+// exceeded. We mirror the `safeGet/safeSet/safeDelete` pattern already
+// used by `agent/storage.ts` for token persistence.
 const STORAGE_KEY_PREFIX = 'beak.agent.pairing.pending.';
 const MAX_AGE_MS = 5 * 60 * 1000;
 
@@ -18,32 +23,64 @@ interface PendingPairing {
 	startedAt: number;
 }
 
+function safeGet(key: string): string | null {
+	try {
+		return window.localStorage.getItem(key);
+	} catch {
+		return null;
+	}
+}
+
+function safeSet(key: string, value: string): boolean {
+	try {
+		window.localStorage.setItem(key, value);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function safeDelete(key: string): void {
+	try {
+		window.localStorage.removeItem(key);
+	} catch {
+		// Best-effort cleanup; quota/disabled errors here can't mask a
+		// successful upstream operation (token exchange already succeeded).
+	}
+}
+
 function storageKeyFor(state: string): string {
 	return `${STORAGE_KEY_PREFIX}${state}`;
 }
 
 function sweepExpired(): void {
 	if (typeof window === 'undefined') return;
-	const now = Date.now();
-	const toDelete: string[] = [];
-	for (let i = 0; i < window.localStorage.length; i++) {
-		const key = window.localStorage.key(i);
-		if (!key?.startsWith(STORAGE_KEY_PREFIX)) continue;
-		const raw = window.localStorage.getItem(key);
-		if (!raw) {
-			toDelete.push(key);
-			continue;
-		}
-		try {
-			const value = JSON.parse(raw) as Partial<PendingPairing>;
-			if (typeof value?.startedAt !== 'number' || now - value.startedAt > MAX_AGE_MS) {
+	try {
+		const now = Date.now();
+		const toDelete: string[] = [];
+		for (let i = 0; i < window.localStorage.length; i++) {
+			const key = window.localStorage.key(i);
+			if (!key?.startsWith(STORAGE_KEY_PREFIX)) continue;
+			const raw = window.localStorage.getItem(key);
+			if (!raw) {
+				toDelete.push(key);
+				continue;
+			}
+			try {
+				const value = JSON.parse(raw) as Partial<PendingPairing>;
+				if (typeof value?.startedAt !== 'number' || now - value.startedAt > MAX_AGE_MS) {
+					toDelete.push(key);
+				}
+			} catch {
 				toDelete.push(key);
 			}
-		} catch {
-			toDelete.push(key);
 		}
+		for (const k of toDelete) safeDelete(k);
+	} catch {
+		// Storage iteration itself failed (disabled / private mode) — no
+		// pending entries are visible, nothing to sweep. Pairing won't work
+		// in this environment, but cold start does.
 	}
-	for (const k of toDelete) window.localStorage.removeItem(k);
 }
 
 /**
@@ -52,6 +89,10 @@ function sweepExpired(): void {
  * is keyed by the `state` token in `localStorage`, so the new tab opened
  * by `window.open` can read the same entry (sessionStorage is per-tab
  * and would be empty in the new tab).
+ *
+ * Throws `pairing_storage_unavailable` if we can't persist the pending
+ * entry — otherwise the user would be redirected to the agent and the
+ * return tab would always fail with `pairing_no_pending`.
  */
 export async function startPairing(baseUrl: string, returnUrl: string): Promise<void> {
 	sweepExpired();
@@ -60,7 +101,9 @@ export async function startPairing(baseUrl: string, returnUrl: string): Promise<
 	const codeChallenge = await codeChallengePromise;
 
 	const pending: PendingPairing = { state, codeVerifier, baseUrl, startedAt: Date.now() };
-	window.localStorage.setItem(storageKeyFor(state), JSON.stringify(pending));
+	if (!safeSet(storageKeyFor(state), JSON.stringify(pending))) {
+		throw new Error('pairing_storage_unavailable');
+	}
 
 	const pairUrl = new URL(`${baseUrl}${AGENT_PAIR_PATH}`);
 	pairUrl.searchParams.set('origin', window.location.origin);
@@ -97,14 +140,16 @@ export interface CompletedPairing {
  * Finish the pair flow: read the pending PKCE state keyed by the `state`
  * token from localStorage, exchange the code for a token, return the
  * token + tokenId. Throws on state mismatch, expired/missing pending
- * pairing, or agent failure.
+ * pairing, or agent failure. `pairing_no_pending` covers both the
+ * legitimate "no record" case and the "storage unavailable" case — the
+ * user-facing remedy is the same: re-start pairing from the host.
  */
 export async function completePairing(query: PairingReturnQuery): Promise<CompletedPairing> {
 	if (query.error) throw new Error(`pairing_${query.error}`);
 	if (!query.code || !query.state) throw new Error('pairing_missing_code_or_state');
 
 	sweepExpired();
-	const raw = window.localStorage.getItem(storageKeyFor(query.state));
+	const raw = safeGet(storageKeyFor(query.state));
 	if (!raw) throw new Error('pairing_no_pending');
 	let pending: PendingPairing;
 	try {
@@ -129,7 +174,10 @@ export async function completePairing(query: PairingReturnQuery): Promise<Comple
 	const parsed = pairTokenResponseSchema.safeParse(json);
 	if (!parsed.success) throw new Error('pairing_invalid_token_response');
 
-	window.localStorage.removeItem(storageKeyFor(query.state));
+	// Best-effort cleanup — if it throws (quota / disabled), the token
+	// exchange already succeeded and we'd rather return the credential
+	// than reject after the agent has minted it.
+	safeDelete(storageKeyFor(query.state));
 	return { token: parsed.data.token, tokenId: parsed.data.tokenId, baseUrl: pending.baseUrl };
 }
 

--- a/packages/ui/src/services/agent/pairing.ts
+++ b/packages/ui/src/services/agent/pairing.ts
@@ -2,7 +2,14 @@ import { AGENT_PAIR_PATH, AGENT_PAIR_TOKEN_PATH, pairTokenResponseSchema } from 
 
 import { newPkcePair, newState } from './crypto';
 
-const SESSION_STORAGE_KEY = 'beak.agent.pairing.pending';
+// Pending pairings are keyed by the CSRF `state` token so the return tab
+// (a separate browser tab opened by `window.open`) can find the matching
+// PKCE verifier in `localStorage`. `sessionStorage` doesn't work here —
+// it's per-tab, and the agent's return URL lands in a fresh tab with an
+// empty sessionStorage. `localStorage` is shared across same-origin tabs,
+// and the `state` lookup means a concurrent second pairing can't collide.
+const STORAGE_KEY_PREFIX = 'beak.agent.pairing.pending.';
+const MAX_AGE_MS = 5 * 60 * 1000;
 
 interface PendingPairing {
 	state: string;
@@ -11,19 +18,49 @@ interface PendingPairing {
 	startedAt: number;
 }
 
+function storageKeyFor(state: string): string {
+	return `${STORAGE_KEY_PREFIX}${state}`;
+}
+
+function sweepExpired(): void {
+	if (typeof window === 'undefined') return;
+	const now = Date.now();
+	const toDelete: string[] = [];
+	for (let i = 0; i < window.localStorage.length; i++) {
+		const key = window.localStorage.key(i);
+		if (!key?.startsWith(STORAGE_KEY_PREFIX)) continue;
+		const raw = window.localStorage.getItem(key);
+		if (!raw) {
+			toDelete.push(key);
+			continue;
+		}
+		try {
+			const value = JSON.parse(raw) as Partial<PendingPairing>;
+			if (typeof value?.startedAt !== 'number' || now - value.startedAt > MAX_AGE_MS) {
+				toDelete.push(key);
+			}
+		} catch {
+			toDelete.push(key);
+		}
+	}
+	for (const k of toDelete) window.localStorage.removeItem(k);
+}
+
 /**
  * Open the pair tab and stash the PKCE verifier so /pair/return can
- * complete the handshake after the user clicks Allow. `sessionStorage`
- * scopes the pending pairing to this browser tab — opening Beak in two
- * tabs at once produces two independent pairings, which is correct.
+ * complete the handshake after the user clicks Allow. The pending entry
+ * is keyed by the `state` token in `localStorage`, so the new tab opened
+ * by `window.open` can read the same entry (sessionStorage is per-tab
+ * and would be empty in the new tab).
  */
 export async function startPairing(baseUrl: string, returnUrl: string): Promise<void> {
+	sweepExpired();
 	const state = newState();
 	const { codeVerifier, codeChallengePromise } = newPkcePair();
 	const codeChallenge = await codeChallengePromise;
 
 	const pending: PendingPairing = { state, codeVerifier, baseUrl, startedAt: Date.now() };
-	window.sessionStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(pending));
+	window.localStorage.setItem(storageKeyFor(state), JSON.stringify(pending));
 
 	const pairUrl = new URL(`${baseUrl}${AGENT_PAIR_PATH}`);
 	pairUrl.searchParams.set('origin', window.location.origin);
@@ -57,15 +94,17 @@ export interface CompletedPairing {
 }
 
 /**
- * Finish the pair flow: read the pending PKCE state from sessionStorage,
- * exchange the code for a token, return the token + tokenId. Throws on
- * state mismatch, expired/missing pending pairing, or agent failure.
+ * Finish the pair flow: read the pending PKCE state keyed by the `state`
+ * token from localStorage, exchange the code for a token, return the
+ * token + tokenId. Throws on state mismatch, expired/missing pending
+ * pairing, or agent failure.
  */
 export async function completePairing(query: PairingReturnQuery): Promise<CompletedPairing> {
 	if (query.error) throw new Error(`pairing_${query.error}`);
 	if (!query.code || !query.state) throw new Error('pairing_missing_code_or_state');
 
-	const raw = window.sessionStorage.getItem(SESSION_STORAGE_KEY);
+	sweepExpired();
+	const raw = window.localStorage.getItem(storageKeyFor(query.state));
 	if (!raw) throw new Error('pairing_no_pending');
 	let pending: PendingPairing;
 	try {
@@ -90,10 +129,11 @@ export async function completePairing(query: PairingReturnQuery): Promise<Comple
 	const parsed = pairTokenResponseSchema.safeParse(json);
 	if (!parsed.success) throw new Error('pairing_invalid_token_response');
 
-	clearPending();
+	window.localStorage.removeItem(storageKeyFor(query.state));
 	return { token: parsed.data.token, tokenId: parsed.data.tokenId, baseUrl: pending.baseUrl };
 }
 
 export function clearPending(): void {
-	window.sessionStorage.removeItem(SESSION_STORAGE_KEY);
+	// No specific state to clear — sweep everything stale and call it done.
+	sweepExpired();
 }

--- a/packages/ui/src/services/web-bridge.ts
+++ b/packages/ui/src/services/web-bridge.ts
@@ -1,0 +1,19 @@
+// Web-shell bridge: a tiny renderer↔web-host channel that lets the renderer
+// publish state the web host's IPC layer needs to scope work per-project.
+//
+// In disk mode, the project id is in the URL (`/project/<id>`) so IPC handlers
+// can derive it directly. In memory mode the URL stays at `/` (no on-disk
+// identity yet), so we leave a hint here for the web host to read.
+
+const ACTIVE_PROJECT_HINT_KEY = 'beak.web.activeProjectId';
+
+export function getActiveProjectIdHint(): string | null {
+	if (typeof window === 'undefined') return null;
+	return window.sessionStorage.getItem(ACTIVE_PROJECT_HINT_KEY);
+}
+
+export function setActiveProjectIdHint(projectId: string | null): void {
+	if (typeof window === 'undefined') return;
+	if (projectId === null) window.sessionStorage.removeItem(ACTIVE_PROJECT_HINT_KEY);
+	else window.sessionStorage.setItem(ACTIVE_PROJECT_HINT_KEY, projectId);
+}

--- a/packages/ui/src/services/web-bridge.ts
+++ b/packages/ui/src/services/web-bridge.ts
@@ -4,16 +4,33 @@
 // In disk mode, the project id is in the URL (`/project/<id>`) so IPC handlers
 // can derive it directly. In memory mode the URL stays at `/` (no on-disk
 // identity yet), so we leave a hint here for the web host to read.
+//
+// `sessionStorage` access can throw in private-mode browsers, when storage
+// has been disabled by the user, or when the quota is exceeded. We swallow
+// the failure here — the host's IPC handlers already tolerate a missing
+// hint (they treat the project as disk-mode-only or no-project) so the
+// renderer keeps booting either way.
 
 const ACTIVE_PROJECT_HINT_KEY = 'beak.web.activeProjectId';
 
 export function getActiveProjectIdHint(): string | null {
 	if (typeof window === 'undefined') return null;
-	return window.sessionStorage.getItem(ACTIVE_PROJECT_HINT_KEY);
+	try {
+		return window.sessionStorage.getItem(ACTIVE_PROJECT_HINT_KEY);
+	} catch {
+		return null;
+	}
 }
 
 export function setActiveProjectIdHint(projectId: string | null): void {
 	if (typeof window === 'undefined') return;
-	if (projectId === null) window.sessionStorage.removeItem(ACTIVE_PROJECT_HINT_KEY);
-	else window.sessionStorage.setItem(ACTIVE_PROJECT_HINT_KEY, projectId);
+	try {
+		if (projectId === null) window.sessionStorage.removeItem(ACTIVE_PROJECT_HINT_KEY);
+		else window.sessionStorage.setItem(ACTIVE_PROJECT_HINT_KEY, projectId);
+	} catch {
+		// sessionStorage disabled (private mode / quota); the host will fall
+		// back to URL-derived scoping and memory-mode work won't be
+		// addressable per-project, which the user is about to find out via
+		// the "Save Project As…" prompt anyway.
+	}
 }

--- a/packages/ui/src/store/effects/project.ts
+++ b/packages/ui/src/store/effects/project.ts
@@ -1,4 +1,3 @@
-import Squawk from '@beak/common/utils/squawk';
 import ksuid from '@beak/ksuid';
 import { provenance } from '@beak/state';
 import {
@@ -11,7 +10,6 @@ import {
 	projectLoadFailed,
 	projectOpened,
 	removeNodeFromStore,
-	removeNodeFromStoreByPath,
 	renameNodeInTree,
 	renameProject,
 	startProject,
@@ -24,7 +22,7 @@ import {
 	makeTabPermanent,
 } from '@beak/ui/features/tabs/store/actions';
 import type { ActiveRename } from '@beak/ui/features/tree-view/types';
-import { createFolderNode, readFolderNode, removeFolderNode, renameFolderNode } from '@beak/ui/lib/beak-project/folder';
+import { createFolderNode, removeFolderNode, renameFolderNode } from '@beak/ui/lib/beak-project/folder';
 import { moveNodesOnDisk } from '@beak/ui/lib/beak-project/nodes';
 import { readProjectFile } from '@beak/ui/lib/beak-project/project';
 import {
@@ -36,7 +34,7 @@ import {
 	unlinkAndPersistAs,
 	writeRequestNode,
 } from '@beak/ui/lib/beak-project/request';
-import { ipcDialogService, ipcEncryptionService, ipcFsService } from '@beak/ui/lib/ipc';
+import { ipcDialogService, ipcFsService } from '@beak/ui/lib/ipc';
 import { loadProject, registerFolderRename, registerRequestRename, startTreeWatcher } from '@beak/ui/services/project';
 import type { FolderNode, RequestNode, Tree } from '@getbeak/types/nodes';
 import path from 'path-browserify';
@@ -44,7 +42,6 @@ import * as uuid from 'uuid';
 import type { AppStartListening } from '../listener';
 import * as projectActions from '../project/actions';
 import {
-	alertInsert,
 	createNewFolder,
 	createNewRequest,
 	duplicateRequest,


### PR DESCRIPTION
## Summary

Started as three cold-start blockers in the web shell; grew to include the
storage-access hardening Copilot flagged, plus the lint and build cleanup
needed to get `beak-host` CI back to green for the first time since PR #671.

## Web shell — cold start (the original three)

**1. `getCurrentProjectId()` crash on `/`** — `apps-host/web/src/ipc/utils.ts`
The regex matchAll returns undefined on the welcome route; reading `matches[1]` threw, which the unhandled-error handler routed to `window.alert()`. Cascaded a modal storm at boot for every IPC handler that called this. Now returns null gracefully.

**2. In-memory project unreachable from IPC handlers** — `apps-host/web/src/ipc/utils.ts`, `packages/ui/src/services/web-bridge.ts` (new), `packages/ui/src/entrypoints/web.tsx`
Memory-mode projects don't navigate the URL (no on-disk identity yet) so URL-keyed handlers couldn't find them. `WebEntrypoint` now syncs `state.global.project.id` to sessionStorage; `getCurrentProjectId` falls back to it when the URL is `/`. Storage access is guarded so private mode / quota-exceeded doesn't reintroduce the boot alert storm.

**3. Pairing flow cross-tab loss** — `packages/ui/src/services/agent/pairing.ts`
The pending PKCE verifier was stored in `sessionStorage` in tab A, but the agent's redirect opens tab B which has its own empty sessionStorage — every pairing attempt failed with `pairing_no_pending`. Switched to `localStorage` keyed by the CSRF `state` token, with a 5-minute sweep on read. All access goes through `safeGet/safeSet/safeDelete` wrappers (mirrors `agent/storage.ts`'s pattern); `startPairing` throws `pairing_storage_unavailable` deterministically before opening the agent tab when storage is broken.

**4. `path_not_project` tolerance in web fs-service** — `apps-host/web/src/ipc/fs-service.ts`
Surfaced during verification of #2: even with the project id wired, `ensureWithinProject` rejects because memory-mode projects have no `project.json` on OPFS. Every handler now treats the missing-project squawk as "nothing to read / nothing to persist" (reads return empty defaults, writes silently swallow), preserving the "memory mode = transient" semantic.

## CI / build — get `beak-host` green

The same workflow that runs against my PR was already failing on master with pre-existing tech debt that nobody had to touch because earlier PRs were docs-only and didn't trigger the `paths:` filter. This PR touches `apps-host/**` and `packages/**`, so we hit all of it:

**Lint (29 errors → 0)** —
- Removed unused imports across `store/effects/project.ts` (5), `electron/ipc-layer/project-service.ts`, `apps-web/share/atoms/Buttons.tsx`, `ProjectMain.tsx`, `OmniRow.tsx`, both banners.
- Replaced `??=` chain in `project-tree/index.ts` with explicit if-assign (`noAssignInExpressions`).
- `children.forEach(el => observer.observe(el))` in `TabView` switched to `for…of` — the previous shape returned `observe`'s value from the callback (`useIterableCallbackReturn`).
- Silenced `noControlCharactersInRegex` on the intentional filename-validation regex in `SourceSchemaDialog` with a `biome-ignore` + rationale (the `\x00-\x1f` range is what the rule's there for, but it's *the* feature here).
- 14× `useHookAtTopLevel`: split `SourceSchemaDialog` into a hook-free dispatcher + `GrpcOrGraphqlSourceSchemaDialog` that owns its 11 `useState`s (the previous shape had an early-return for the OpenAPI branch ahead of all of them); hoisted hooks above early-returns in `RequestTab` and `Workflows`.
- Set `javascript.jsxRuntime: "reactClassic"` in `biome.json` so biome matches our tsconfig (`jsx: react`) — otherwise JSX-only `React` imports get flagged unused.

**Production build (vite alias bug)** —
`apps-host/web/vite.config.js:37` mapped `@beak/ui` to `../../packages/ui/${sourcePathInDev}`, which collapsed to `../../packages/ui/` (trailing slash) in production. `@beak/ui/services/agent` then resolved to `../../packages/ui//services/agent` and the bundler choked. Always point at `src/`.

**Electron build — Sentry CLI interop** —
`@sentry/cli` 3.4.2 exports a named class (`SentryCli`); the previous `(SentryCliModule as any).default ?? SentryCliModule` fallback landed on the package's namespace object, which isn't a constructor (`SentryCliCtor is not a constructor` in CI). Switched to `import { SentryCli } from '@sentry/cli'`; the proper types now flow through, so `releases.new(...)` correctly takes its options arg.

**Electron build — `electron-builder` version detection** —
electron-builder walks `node_modules` looking for `electron` / `electron-prebuilt` / `electron-prebuilt-compile`. With pnpm's hoisted linker the package lives at the workspace root, not in `apps-host/electron/node_modules/`, so the lookup misses. The fallback is the version range in package.json, but `^37.10.3` isn't accepted as "fixed". Pinned `electronVersion: "37.10.3"` in `electron-builder.json` to bypass the lookup entirely.

## Tooling — local CI iteration via `act`

`.actrc` (committed) configures `act` with the right defaults for this repo:
- `--container-architecture linux/amd64` so Apple Silicon doesn't try to pull arm64-only images.
- `-P macos-latest=catthehacker/ubuntu:act-latest` substitute (act can't actually run macOS — but everything up to the platform-specific signing step runs identically on Linux).
- `--secret-file .secrets.act.local` (gitignored; the file holds dummy SENTRY/APPLE/AWS/CSC values that satisfy env-var checks).

Usage: `act -j build-deploy`, `act --dryrun`, `act -j build-deploy --reuse`.

## Vercel removed

The Vercel build badge in `README.md` is gone. The Vercel project for `apps-web-marketing` should be deleted from the Vercel dashboard (out of repo scope).

## Test plan

Verified end-to-end via Playwright (screenshots in `screenshots/post-fix-*` locally, not committed):

- [x] Welcome screen at `/` boots with **0 errors** (was 20+ alert dialogs)
- [x] "New request" creates an Untitled project, request editor renders with URL / headers / body tabs
- [x] "Pair agent" → new tab → "Allow" → redirect back → token + tokenId land in localStorage
- [x] Live `GET https://httpbin.org/anything` through the agent returns **200 OK** with JSON tree viewer ready
- [x] `pnpm lint` exit 0 (was 29 errors)
- [x] `pnpm typecheck:apps-host` exit 0 across all workspaces
- [x] `pnpm build` exit 0 across all workspaces (web build was hard-broken on master)
- [x] `pnpm package` runs end-to-end on macOS through electron-builder to the notarization step (which needs CI's signing certs)

## Still open

- **macOS notarization** rejects unsigned `.node` binaries inside `node_modules/isolated-vm/{isolated-vm-*.tgz,prebuilds/,bin/}` that ship in `app.asar.unpacked`. Tactical fix: prune them in `scripts/after-pack.js` before signing. Strategic fix: replace `isolated-vm` with `node:worker_threads` so the extension sandbox stops shipping native code (also lets the electron and web hosts converge on a Worker-based model). Deciding which path to take next is the only thing between this PR and a fully-green CI.
- **Vercel apps-web-marketing** preview deploy fails — unrelated to this PR's diff.