### PR TITLE
feat(extensions): unify electron + web on a Worker-based sandbox (drop isolated-vm)

### DIFF
--- a/apps-host/electron/esbuild.main.config.ts
+++ b/apps-host/electron/esbuild.main.config.ts
@@ -109,9 +109,7 @@ export default [
 		},
 		sourcemap: true,
 		assetNames: '[name]',
-		// isolated-vm is a native module — leave it out of the bundle so the
-		// .node binding resolves correctly at runtime from node_modules.
-		external: ['node:fs', 'isolated-vm'],
+		external: ['node:fs'],
 	},
 ] as BuildOptions[];
 

--- a/apps-host/electron/package.json
+++ b/apps-host/electron/package.json
@@ -16,7 +16,6 @@
 		"prepackage:release": "rm -rf ./dist-electron",
 		"package": "electron-builder -mw --publish never",
 		"package:release": "electron-builder -mw --publish always",
-		"postinstall": "electron-rebuild -f -w isolated-vm",
 		"start": "cross-env NODE_ENV=development electron-esbuild dev",
 		"typecheck": "tsgo",
 		"lint": "biome lint .",
@@ -50,7 +49,6 @@
 		"keytar": "^7.9.0",
 		"lodash.clonedeep": "^4.5.0",
 		"semver": "^7.8.0",
-		"isolated-vm": "^6.1.2",
 		"source-map-support": "^0.5.21",
 		"tslog": "^4.10.2",
 		"uuid": "^14.0.0"

--- a/apps-host/electron/src/ipc-layer/extensions-service.ts
+++ b/apps-host/electron/src/ipc-layer/extensions-service.ts
@@ -152,7 +152,12 @@ service.registerSearch(async (_event, payload) => {
 service.registerVariableCreateDefaultPayload(async (event, payload) => {
 	const invokeEvent = event as IpcMainInvokeEvent;
 	const { projectId } = await getProjectId(invokeEvent);
-	return await extensionManager.variableCreateDefaultPayload(projectId, payload.type, payload.context, invokeEvent.sender);
+	return await extensionManager.variableCreateDefaultPayload(
+		projectId,
+		payload.type,
+		payload.context,
+		invokeEvent.sender,
+	);
 });
 
 service.registerVariableGetValue(async (event, payload) => {

--- a/apps-host/electron/src/ipc-layer/extensions-service.ts
+++ b/apps-host/electron/src/ipc-layer/extensions-service.ts
@@ -38,7 +38,11 @@ service.registerList(async event => {
 
 	for (const entry of installed) {
 		try {
-			const loaded = await extensionManager.load(event, projectId, entry.absolutePath);
+			const loaded = await extensionManager.load(projectId, entry.absolutePath, {
+				validateScriptPath: async scriptPath => {
+					await ensureWithinProject(getProjectFolder(event as IpcMainInvokeEvent), scriptPath);
+				},
+			});
 			results.push(loaded);
 		} catch (error) {
 			results.push({
@@ -66,7 +70,11 @@ service.registerInstall(async (event, payload) => {
 	await ensureWithinProject(getProjectFolder(invokeEvent), destination);
 	await getBeakHost().projectExtensions.addDependency(extensionsDir, resolved.packageName, resolved.version);
 
-	const loaded = await extensionManager.load(invokeEvent, projectId, destination);
+	const loaded = await extensionManager.load(projectId, destination, {
+		validateScriptPath: async scriptPath => {
+			await ensureWithinProject(getProjectFolder(invokeEvent), scriptPath);
+		},
+	});
 	return loaded;
 });
 
@@ -97,7 +105,11 @@ service.registerUpdate(async (event, payload) => {
 	await ensureWithinProject(getProjectFolder(invokeEvent), destination);
 	await getBeakHost().projectExtensions.addDependency(extensionsDir, resolved.packageName, resolved.version);
 
-	const loaded = await extensionManager.load(invokeEvent, projectId, destination);
+	const loaded = await extensionManager.load(projectId, destination, {
+		validateScriptPath: async scriptPath => {
+			await ensureWithinProject(getProjectFolder(invokeEvent), scriptPath);
+		},
+	});
 	return loaded;
 });
 
@@ -138,8 +150,9 @@ service.registerSearch(async (_event, payload) => {
 /* -------------------------------------------------------------------------- */
 
 service.registerVariableCreateDefaultPayload(async (event, payload) => {
-	const { projectId } = await getProjectId(event as IpcMainInvokeEvent);
-	return await extensionManager.variableCreateDefaultPayload(projectId, payload.type, payload.context);
+	const invokeEvent = event as IpcMainInvokeEvent;
+	const { projectId } = await getProjectId(invokeEvent);
+	return await extensionManager.variableCreateDefaultPayload(projectId, payload.type, payload.context, invokeEvent.sender);
 });
 
 service.registerVariableGetValue(async (event, payload) => {
@@ -169,21 +182,31 @@ service.registerVariableGetAssetRef(async (event, payload) => {
 });
 
 service.registerVariableEditorCreateUI(async (event, payload) => {
-	const { projectId } = await getProjectId(event as IpcMainInvokeEvent);
-	return await extensionManager.variableEditorCreateUI(projectId, payload.type, payload.context);
+	const invokeEvent = event as IpcMainInvokeEvent;
+	const { projectId } = await getProjectId(invokeEvent);
+	return await extensionManager.variableEditorCreateUI(projectId, payload.type, payload.context, invokeEvent.sender);
 });
 
 service.registerVariableEditorLoad(async (event, payload) => {
-	const { projectId } = await getProjectId(event as IpcMainInvokeEvent);
-	return await extensionManager.variableEditorLoad(projectId, payload.type, payload.context, payload.payload);
+	const invokeEvent = event as IpcMainInvokeEvent;
+	const { projectId } = await getProjectId(invokeEvent);
+	return await extensionManager.variableEditorLoad(
+		projectId,
+		payload.type,
+		payload.context,
+		invokeEvent.sender,
+		payload.payload,
+	);
 });
 
 service.registerVariableEditorSave(async (event, payload) => {
-	const { projectId } = await getProjectId(event as IpcMainInvokeEvent);
+	const invokeEvent = event as IpcMainInvokeEvent;
+	const { projectId } = await getProjectId(invokeEvent);
 	return await extensionManager.variableEditorSave(
 		projectId,
 		payload.type,
 		payload.context,
+		invokeEvent.sender,
 		payload.existingPayload,
 		payload.state,
 	);

--- a/apps-host/electron/src/lib/extension/index.ts
+++ b/apps-host/electron/src/lib/extension/index.ts
@@ -1,461 +1,130 @@
 import path from 'node:path';
+import { Worker as NodeWorker } from 'node:worker_threads';
 
-import { ensureWithinProject } from '@beak/apps-host-electron/ipc-layer/fs-service';
-import { getProjectFolder } from '@beak/apps-host-electron/ipc-layer/utils';
 import {
 	ExtensionsMessages,
 	type IpcExtensionsServiceMain,
 	type VariableParseValueSectionsResponse,
 } from '@beak/common/ipc/extensions';
 import type { IpcMessage } from '@beak/common/ipc/types';
-import type { Extension, ExtensionVariable, LoadedExtension } from '@beak/common/types/extensions';
 import Squawk from '@beak/common/utils/squawk';
 import ksuid from '@beak/ksuid';
 import {
-	ExtensionManifests,
-	makeFullyQualifiedType,
-	ProjectExtensionRegistry,
-	packageNameFromType,
+	type UnifiedWorker,
+	WORKER_RUNTIME_NODE_SHIM,
+	WORKER_SOURCE,
+	WorkerExtensionManager,
+	type WorkerProvider,
 } from '@beak/runtime-shared/extensions';
 import type { ValueSections, Context as VariableContext } from '@getbeak/types/values';
-import { type IpcMainInvokeEvent, type IpcRendererEvent, ipcMain, type WebContents } from 'electron';
-import fs from 'fs-extra';
-import ivm from 'isolated-vm';
+import { ipcMain, type WebContents } from 'electron';
 import { Logger } from 'tslog';
 
 import getBeakHost from '../../host';
-import { type LogLevel, setupLoggerForFsLogging } from '../logger';
-
-type IpcEvent = IpcMainInvokeEvent | IpcRendererEvent;
-type RequestPayload<T> = IpcMessage<T>;
-
-interface IsolateRecord {
-	isolate: ivm.Isolate;
-	context: ivm.Context;
-	/** Map of fully-qualified type (`external:<pkg>/<id>`) → callable handles inside the isolate. */
-	variables: Record<string, VariableHandles>;
-	loaded: LoadedExtension;
-}
-
-interface VariableHandles {
-	createDefaultPayload: ivm.Reference;
-	getValue: ivm.Reference;
-	getAssetRef: ivm.Reference | null;
-	editor: {
-		createUserInterface: ivm.Reference;
-		load: ivm.Reference | null;
-		save: ivm.Reference | null;
-	} | null;
-}
+import { setupLoggerForFsLogging } from '../logger';
 
 const logger = new Logger({ name: 'extensions' });
 setupLoggerForFsLogging(logger, 'extensions');
 
-const ISOLATE_MEMORY_LIMIT_MB = 64;
-const ISOLATE_BOOT_TIMEOUT_MS = 2_000;
 const PARSE_VALUE_SECTIONS_TIMEOUT_MS = 30_000;
 
-/* -------------------------------------------------------------------------- */
-/*  Bootstrap shim                                                            */
-/* -------------------------------------------------------------------------- */
-
 /**
- * Wrapper script run inside each extension's isolate. Provides a minimal
- * CommonJS-flavoured environment, materialises a host-backed
- * `ExtensionContext`, binds it to every user callback so the SDK's
- * `(extCtx, varCtx, payload, depth)` signature works naturally, and
- * exposes copyable metadata + callable wrappers back to the host.
+ * Electron extension manager — runs each extension in a `node:worker_threads`
+ * Worker (one V8 isolate + event loop per extension), routes the worker's
+ * recursive `parseValueSections` callbacks back through the renderer via
+ * IPC, and logs via `tslog`. Replaces the legacy `isolated-vm` implementation;
+ * see ADR-0003 for the rationale and trust-model details.
  *
- * `${USER_SOURCE}` is substituted with the extension's bundled main.
- *
- * The script ends by evaluating to `undefined`; the host reads
- * `__beak_metadata` (copyable) and `__beak_handles` (reference) off the
- * global after execution.
+ * `callerCtx` is `WebContents` — the renderer that initiated the call.
+ * Stored per-worker so each `parse-value-sections` response targets the
+ * right window when multiple project windows are open.
  */
-function buildBootScript(userSource: string): string {
-	return `
-(function () {
-	const module = { exports: {} };
-	const exports = module.exports;
-
-	const extCtx = {
-		log: (level, message) => {
-			try { __beak_log.applyIgnored(undefined, [String(level), String(message)]); }
-			catch (e) { /* swallow — logger failures must not crash the extension */ }
-		},
-		parseValueSections: (varCtx, parts) =>
-			__beak_parseValueSections.apply(undefined, [varCtx, parts], {
-				arguments: { copy: true },
-				result: { copy: true, promise: true },
-			}),
-	};
-
-	(function (module, exports) {
-		${userSource}
-	})(module, exports);
-
-	const raw = (module.exports && (module.exports.default ?? module.exports));
-	if (!raw || typeof raw !== 'object')
-		throw new Error('Extension did not export a definition. Did you forget to export default defineExtension(...)?');
-
-	if (raw.apiVersion !== 1)
-		throw new Error('Extension declared an unsupported apiVersion: ' + raw.apiVersion);
-
-	if (!Array.isArray(raw.variables) || raw.variables.length === 0)
-		throw new Error('Extension does not contribute any variables.');
-
-	const metadata = [];
-	const handles = {};
-
-	for (const variable of raw.variables) {
-		if (typeof variable.id !== 'string' || variable.id.length === 0)
-			throw new Error('A contributed variable is missing its id.');
-		if (typeof variable.name !== 'string')
-			throw new Error('Variable ' + variable.id + ' is missing a name.');
-		if (typeof variable.description !== 'string')
-			throw new Error('Variable ' + variable.id + ' is missing a description.');
-		if (typeof variable.createDefaultPayload !== 'function')
-			throw new Error('Variable ' + variable.id + ' is missing createDefaultPayload.');
-		if (typeof variable.getValue !== 'function')
-			throw new Error('Variable ' + variable.id + ' is missing getValue.');
-
-		const editor = variable.editor && typeof variable.editor === 'object'
-			? {
-				createUserInterface: typeof variable.editor.createUserInterface === 'function'
-					? variable.editor.createUserInterface : null,
-				load: typeof variable.editor.load === 'function' ? variable.editor.load : null,
-				save: typeof variable.editor.save === 'function' ? variable.editor.save : null,
-			}
-			: null;
-
-		if (editor && !editor.createUserInterface)
-			throw new Error('Variable ' + variable.id + ' has an editor without createUserInterface.');
-
-		metadata.push({
-			variableId: variable.id,
-			name: variable.name,
-			description: variable.description,
-			sensitive: Boolean(variable.sensitive),
-			keywords: Array.isArray(variable.keywords) ? variable.keywords.slice() : [],
-			attributes: variable.attributes && typeof variable.attributes === 'object'
-				? { requiresRequestId: Boolean(variable.attributes.requiresRequestId) }
-				: { requiresRequestId: false },
-			editable: Boolean(editor),
-			binary: typeof variable.getAssetRef === 'function',
-		});
-
-		handles[variable.id] = {
-			createDefaultPayload: (varCtx) => variable.createDefaultPayload(extCtx, varCtx),
-			getValue: (varCtx, payload, depth) => variable.getValue(extCtx, varCtx, payload, depth),
-			getAssetRef: typeof variable.getAssetRef === 'function'
-				? (varCtx, payload, depth) => variable.getAssetRef(extCtx, varCtx, payload, depth)
-				: null,
-			editor: editor ? {
-				createUserInterface: (varCtx) => editor.createUserInterface(extCtx, varCtx),
-				load: editor.load ? (varCtx, payload) => editor.load(extCtx, varCtx, payload) : null,
-				save: editor.save ? (varCtx, existing, state) => editor.save(extCtx, varCtx, existing, state) : null,
-			} : null,
-		};
-	}
-
-	global.__beak_metadata = new __beak_ivm_ExternalCopy(metadata).copyInto();
-	global.__beak_handles = handles;
-})();
-`;
-}
-
-/* -------------------------------------------------------------------------- */
-/*  Manager                                                                   */
-/* -------------------------------------------------------------------------- */
-
-export default class ExtensionManager {
-	private readonly registry = new ProjectExtensionRegistry<IsolateRecord>({
-		dispose: disposeIsolate,
-	});
-	private readonly service: IpcExtensionsServiceMain;
-
+export default class ExtensionManager extends WorkerExtensionManager<WebContents> {
 	constructor(service: IpcExtensionsServiceMain) {
-		this.service = service;
-	}
-
-	/**
-	 * Reset every isolate for a project. Used by the management IPC when
-	 * the on-disk extensions/ tree has been mutated and the renderer is
-	 * about to re-register everything.
-	 */
-	async resetProject(projectId: string): Promise<void> {
-		await this.registry.resetProject(projectId);
-	}
-
-	/**
-	 * Load an extension into its own isolate, validate the contributed
-	 * variables, and return a `LoadedExtension` describing what's
-	 * available. Idempotent — re-loading the same package replaces its
-	 * isolate cleanly.
-	 */
-	async load(event: IpcEvent, projectId: string, extensionPath: string): Promise<LoadedExtension> {
-		const manifests = new ExtensionManifests(getBeakHost().providers);
-		const manifest = await manifests.parse(extensionPath, {
-			validateScriptPath: async scriptPath => {
-				await ensureWithinProject(getProjectFolder(event), scriptPath);
+		super({
+			providers: getBeakHost().providers,
+			workerProvider: new NodeWorkerProvider(),
+			callbacks: {
+				parseValueSections: (callerCtx, varCtx, parts, recursiveDepth) =>
+					parseValueSectionsViaIpc(service, callerCtx, varCtx, parts, recursiveDepth),
+				log: (packageName, level, message) => {
+					const fn =
+						(logger as unknown as Record<string, (m: string) => void>)[level] ?? logger.warn.bind(logger);
+					fn(`[${packageName}] ${message}`);
+				},
 			},
 		});
-		const userSource = await fs.readFile(manifest.scriptPath, 'utf8');
+	}
+}
 
-		const isolate = new ivm.Isolate({ memoryLimit: ISOLATE_MEMORY_LIMIT_MB });
-		const context = await isolate.createContext();
-		const global = context.global;
+class NodeWorkerProvider implements WorkerProvider {
+	spawn(name: string): UnifiedWorker {
+		const fullSource = `${WORKER_RUNTIME_NODE_SHIM}\n${WORKER_SOURCE}`;
+		const worker = new NodeWorker(fullSource, { eval: true, name });
+		return new NodeWorkerAdapter(worker);
+	}
+}
 
-		await global.set('global', global.derefInto());
+class NodeWorkerAdapter implements UnifiedWorker {
+	constructor(private readonly worker: NodeWorker) {}
 
-		// Wire host helpers used by the bootstrap script and the extCtx wrapper.
-		await global.set(
-			'__beak_log',
-			new ivm.Reference((level: LogLevel, message: string) => {
-				const fn = (logger as unknown as Record<string, (m: string) => void>)[level] ?? logger.warn.bind(logger);
-				fn(`[${manifest.packageName}] ${message}`);
-			}),
-		);
+	postMessage(message: unknown): void {
+		this.worker.postMessage(message);
+	}
 
-		// Placeholder — re-bound per call by `variableGetValue` so the right
-		// webContents receives the parse callback.
-		await global.set('__beak_parseValueSections', new ivm.Reference(async () => ''));
+	onMessage(listener: (message: unknown) => void): () => void {
+		this.worker.on('message', listener);
+		return () => this.worker.off('message', listener);
+	}
 
-		// Expose isolated-vm constructors inside the isolate for the bootstrap shim.
-		await global.set('__beak_ivm_ExternalCopy', ivm.ExternalCopy);
-		await global.set('__beak_ivm_Reference', ivm.Reference);
+	onError(listener: (error: unknown) => void): () => void {
+		this.worker.on('error', listener);
+		return () => this.worker.off('error', listener);
+	}
 
-		const script = await isolate.compileScript(buildBootScript(userSource));
-		await script.run(context, { timeout: ISOLATE_BOOT_TIMEOUT_MS });
+	terminate(): Promise<unknown> {
+		return this.worker.terminate();
+	}
+}
 
-		const metadataRaw = (await global.get('__beak_metadata', { copy: true })) as ExtensionVariable[] | undefined;
-		const handlesRef = (await global.get('__beak_handles', { reference: true })) as ivm.Reference | undefined;
+function parseValueSectionsViaIpc(
+	service: IpcExtensionsServiceMain,
+	webContents: WebContents,
+	varCtx: VariableContext,
+	parts: ValueSections,
+	recursiveDepth: number,
+): Promise<string> {
+	const uniqueSessionId = ksuid.generate('rtvparsersp').toString();
 
-		if (!metadataRaw || !handlesRef)
-			throw new Squawk('extension_bootstrap_incomplete', { packageName: manifest.packageName });
+	return new Promise<string>((resolve, reject) => {
+		const listener = (_event: unknown, message: unknown) => {
+			const { code, payload } = message as IpcMessage<VariableParseValueSectionsResponse>;
+			if (code !== ExtensionsMessages.VariableParseValueSectionsResponse) return;
+			if (payload.uniqueSessionId !== uniqueSessionId) return;
 
-		const variables: ExtensionVariable[] = metadataRaw.map(meta => ({
-			...meta,
-			type: makeFullyQualifiedType(manifest.packageName, meta.variableId),
-		}));
-
-		const variableHandles: Record<string, VariableHandles> = {};
-		for (const meta of variables) {
-			const variableRef = await handlesRef.get(meta.variableId, { reference: true });
-			if (!variableRef) throw new Squawk('extension_variable_handle_missing', { variableId: meta.variableId });
-
-			variableHandles[meta.type] = {
-				createDefaultPayload: await variableRef.get('createDefaultPayload', { reference: true }),
-				getValue: await variableRef.get('getValue', { reference: true }),
-				getAssetRef: meta.binary ? await variableRef.get('getAssetRef', { reference: true }) : null,
-				editor: meta.editable
-					? {
-							createUserInterface: await (await variableRef.get('editor', { reference: true })).get('createUserInterface', {
-								reference: true,
-							}),
-							load: await tryGetMember(variableRef, 'editor', 'load'),
-							save: await tryGetMember(variableRef, 'editor', 'save'),
-						}
-					: null,
-			};
-		}
-
-		const loaded: LoadedExtension = {
-			status: 'loaded',
-			packageName: manifest.packageName,
-			version: manifest.version,
-			displayName: manifest.displayName,
-			description: manifest.description,
-			author: manifest.author,
-			homepage: manifest.homepage,
-			filePath: extensionPath,
-			apiVersion: 1,
-			variables,
+			cleanup();
+			resolve(payload.parsed);
 		};
 
-		// Hand the record to the shared registry — it manages dispose-on-replace
-		// and the projects bucket. Per-project lifecycle (resetProject, unload,
-		// list, resolve) is identical across both hosts and now lives there.
-		await this.registry.insert(projectId, manifest.packageName, {
-			isolate,
-			context,
-			variables: variableHandles,
-			loaded,
+		const timer = setTimeout(() => {
+			cleanup();
+			reject(new Squawk('parse_value_sections_timeout', { uniqueSessionId, timeoutMs: PARSE_VALUE_SECTIONS_TIMEOUT_MS }));
+		}, PARSE_VALUE_SECTIONS_TIMEOUT_MS);
+
+		function cleanup() {
+			clearTimeout(timer);
+			ipcMain.off('extensions', listener);
+		}
+
+		ipcMain.on('extensions', listener);
+
+		service.variableParseValueSections(webContents, {
+			uniqueSessionId,
+			context: varCtx,
+			parts,
+			recursiveDepth,
 		});
-
-		return loaded;
-	}
-
-	async unload(projectId: string, packageName: string): Promise<void> {
-		await this.registry.unload(projectId, packageName);
-	}
-
-	list(projectId: string): Extension[] {
-		return this.registry.list(projectId);
-	}
-
-	/* ---- Variable invocation ------------------------------------------ */
-
-	async variableCreateDefaultPayload(
-		projectId: string,
-		type: string,
-		varCtx: VariableContext,
-	): Promise<Record<string, unknown>> {
-		const { handles } = this.resolve(projectId, type);
-		return await callIntoIsolate(handles.createDefaultPayload, [varCtx]);
-	}
-
-	async variableGetValue(
-		projectId: string,
-		type: string,
-		varCtx: VariableContext,
-		webContents: WebContents,
-		payload: unknown,
-		recursiveDepth: number,
-	): Promise<string> {
-		const { handles, record } = this.resolve(projectId, type);
-
-		await this.bindParseValueSections(record, webContents, recursiveDepth);
-
-		return await callIntoIsolate(handles.getValue, [varCtx, payload, recursiveDepth]);
-	}
-
-	async variableGetAssetRef(
-		projectId: string,
-		type: string,
-		varCtx: VariableContext,
-		webContents: WebContents,
-		payload: unknown,
-		recursiveDepth: number,
-	): Promise<{ sha256: string; size: number; contentType?: string } | null> {
-		const { handles, record } = this.resolve(projectId, type);
-		if (!handles.getAssetRef) return null;
-
-		await this.bindParseValueSections(record, webContents, recursiveDepth);
-
-		return await callIntoIsolate(handles.getAssetRef, [varCtx, payload, recursiveDepth]);
-	}
-
-	async variableEditorCreateUI(projectId: string, type: string, varCtx: VariableContext) {
-		const { handles } = this.resolve(projectId, type);
-		if (!handles.editor) throw new Squawk('extension_editor_missing', { type });
-
-		return await callIntoIsolate(handles.editor.createUserInterface, [varCtx]);
-	}
-
-	async variableEditorLoad(projectId: string, type: string, varCtx: VariableContext, payload: unknown) {
-		const { handles } = this.resolve(projectId, type);
-		if (!handles.editor?.load) throw new Squawk('extension_editor_missing_method', { type, method: 'load' });
-
-		return await callIntoIsolate(handles.editor.load, [varCtx, payload]);
-	}
-
-	async variableEditorSave(
-		projectId: string,
-		type: string,
-		varCtx: VariableContext,
-		existingPayload: unknown,
-		state: unknown,
-	) {
-		const { handles } = this.resolve(projectId, type);
-		if (!handles.editor?.save) throw new Squawk('extension_editor_missing_method', { type, method: 'save' });
-
-		return await callIntoIsolate(handles.editor.save, [varCtx, existingPayload, state]);
-	}
-
-	/* ---- Internals ----------------------------------------------------- */
-
-	/**
-	 * Look up the per-package record + per-type variable handles. The
-	 * registry's `byPackage` returns the record; each host applies its
-	 * own per-type lookup (electron stores `variables[fullyQualifiedType]`).
-	 */
-	private resolve(projectId: string, type: string): { record: IsolateRecord; handles: VariableHandles } {
-		const packageName = packageNameFromType(type);
-		const record = this.registry.byPackage(projectId, packageName);
-		const handles = record?.variables[type];
-		if (!record || !handles) throw new Squawk('unknown_registered_extension', { projectId, type });
-		return { record, handles };
-	}
-
-	private async bindParseValueSections(
-		record: IsolateRecord,
-		webContents: WebContents,
-		recursiveDepth: number,
-	): Promise<void> {
-		const service = this.service;
-		const ref = new ivm.Reference(async (varCtx: VariableContext, parts: ValueSections) => {
-			const uniqueSessionId = ksuid.generate('rtvparsersp').toString();
-
-			service.variableParseValueSections(webContents, {
-				uniqueSessionId,
-				context: varCtx,
-				parts,
-				recursiveDepth,
-			});
-
-			return await new Promise<string>((resolve, reject) => {
-				const listener = (_event: unknown, message: unknown) => {
-					const { code, payload } = message as RequestPayload<VariableParseValueSectionsResponse>;
-					if (code !== ExtensionsMessages.VariableParseValueSectionsResponse) return;
-					if (payload.uniqueSessionId !== uniqueSessionId) return;
-
-					clearTimeout(timeoutHandle);
-					ipcMain.off('extensions', listener);
-					resolve(payload.parsed);
-				};
-
-				const timeoutHandle = setTimeout(() => {
-					ipcMain.off('extensions', listener);
-					reject(
-						new Squawk('parse_value_sections_timeout', {
-							uniqueSessionId,
-							timeoutMs: PARSE_VALUE_SECTIONS_TIMEOUT_MS,
-						}),
-					);
-				}, PARSE_VALUE_SECTIONS_TIMEOUT_MS);
-
-				ipcMain.on('extensions', listener);
-			});
-		});
-
-		await record.context.global.set('__beak_parseValueSections', ref);
-	}
-}
-
-/* -------------------------------------------------------------------------- */
-/*  Helpers                                                                   */
-/* -------------------------------------------------------------------------- */
-
-async function callIntoIsolate<TResult>(reference: ivm.Reference, args: unknown[]): Promise<TResult> {
-	return (await reference.apply(undefined, args, {
-		arguments: { copy: true },
-		result: { copy: true, promise: true },
-	})) as TResult;
-}
-
-async function tryGetMember(parent: ivm.Reference, group: string, member: string): Promise<ivm.Reference | null> {
-	try {
-		const groupRef = await parent.get(group, { reference: true });
-		const memberRef = await groupRef.get(member, { reference: true });
-		return memberRef.typeof === 'function' ? memberRef : null;
-	} catch {
-		return null;
-	}
-}
-
-function disposeIsolate(record: IsolateRecord): void {
-	try {
-		record.context.release();
-	} catch {
-		/* already released */
-	}
-
-	try {
-		record.isolate.dispose();
-	} catch {
-		/* already disposed */
-	}
+	});
 }
 
 /**

--- a/apps-host/electron/src/lib/extension/index.ts
+++ b/apps-host/electron/src/lib/extension/index.ts
@@ -48,8 +48,7 @@ export default class ExtensionManager extends WorkerExtensionManager<WebContents
 				parseValueSections: (callerCtx, varCtx, parts, recursiveDepth) =>
 					parseValueSectionsViaIpc(service, callerCtx, varCtx, parts, recursiveDepth),
 				log: (packageName, level, message) => {
-					const fn =
-						(logger as unknown as Record<string, (m: string) => void>)[level] ?? logger.warn.bind(logger);
+					const fn = (logger as unknown as Record<string, (m: string) => void>)[level] ?? logger.warn.bind(logger);
 					fn(`[${packageName}] ${message}`);
 				},
 			},

--- a/apps-host/web/src/ipc/extensions-service.ts
+++ b/apps-host/web/src/ipc/extensions-service.ts
@@ -130,7 +130,7 @@ service.registerSearch(async (_event, payload) => {
 
 service.registerVariableCreateDefaultPayload(async (_event, payload) => {
 	const { projectId } = projectContext();
-	return await manager.variableCreateDefaultPayload(projectId, payload.type, payload.context);
+	return await manager.variableCreateDefaultPayload(projectId, payload.type, payload.context, null);
 });
 
 service.registerVariableGetValue(async (_event, payload) => {
@@ -139,6 +139,7 @@ service.registerVariableGetValue(async (_event, payload) => {
 		projectId,
 		payload.type,
 		payload.context,
+		null,
 		payload.payload,
 		payload.recursiveDepth,
 	);
@@ -150,6 +151,7 @@ service.registerVariableGetAssetRef(async (_event, payload) => {
 		projectId,
 		payload.type,
 		payload.context,
+		null,
 		payload.payload,
 		payload.recursiveDepth,
 	);
@@ -157,12 +159,12 @@ service.registerVariableGetAssetRef(async (_event, payload) => {
 
 service.registerVariableEditorCreateUI(async (_event, payload) => {
 	const { projectId } = projectContext();
-	return await manager.variableEditorCreateUI(projectId, payload.type, payload.context);
+	return await manager.variableEditorCreateUI(projectId, payload.type, payload.context, null);
 });
 
 service.registerVariableEditorLoad(async (_event, payload) => {
 	const { projectId } = projectContext();
-	return await manager.variableEditorLoad(projectId, payload.type, payload.context, payload.payload);
+	return await manager.variableEditorLoad(projectId, payload.type, payload.context, null, payload.payload);
 });
 
 service.registerVariableEditorSave(async (_event, payload) => {
@@ -171,6 +173,7 @@ service.registerVariableEditorSave(async (_event, payload) => {
 		projectId,
 		payload.type,
 		payload.context,
+		null,
 		payload.existingPayload,
 		payload.state,
 	);

--- a/apps-host/web/src/lib/extension/manager.ts
+++ b/apps-host/web/src/lib/extension/manager.ts
@@ -4,339 +4,129 @@ import {
 	type VariableParseValueSectionsResponse,
 } from '@beak/common/ipc/extensions';
 import type { IpcMessage } from '@beak/common/ipc/types';
-import type { Extension, ExtensionVariable, LoadedExtension } from '@beak/common/types/extensions';
 import Squawk from '@beak/common/utils/squawk';
 import ksuid from '@beak/ksuid';
 import {
-	ExtensionManifests,
-	makeFullyQualifiedType,
-	ProjectExtensionRegistry,
-	packageNameFromType,
-	variableIdFromType,
+	type UnifiedWorker,
+	WORKER_SOURCE,
+	WorkerExtensionManager,
+	type WorkerProvider,
 } from '@beak/runtime-shared/extensions';
 import type { ValueSections, Context as VariableContext } from '@getbeak/types/values';
 
 import getRuntime from '../../host';
 import { webIpcMain } from '../../ipc/ipc';
-import { WORKER_SOURCE } from './worker-source';
 
-interface WorkerRecord {
-	worker: Worker;
-	loaded: LoadedExtension;
-	pendingCalls: Map<string, { resolve: (v: unknown) => void; reject: (e: unknown) => void }>;
-}
-
-const INIT_TIMEOUT_MS = 5_000;
-const CALL_TIMEOUT_MS = 30_000;
+const PARSE_VALUE_SECTIONS_TIMEOUT_MS = 30_000;
 
 /**
- * Manages one Web Worker per loaded extension. Mirrors the electron
- * `ExtensionManager` surface — same method names, same return shapes —
- * so the IPC handlers can call into either side without branching.
+ * Web-shell extension manager — a thin adapter that supplies the shared
+ * `WorkerExtensionManager` with a Web Worker provider, the IPC roundtrip
+ * for recursive `parseValueSections` calls, and a logger sink. Public API
+ * is unchanged from the previous bespoke implementation; callers in
+ * `apps-host/web/src/ipc/extensions-service.ts` keep working untouched.
+ *
+ * `callerCtx` is `null` on the web — there is only one renderer process,
+ * so there's nothing to demultiplex by.
  */
-export default class WebExtensionManager {
-	private readonly registry = new ProjectExtensionRegistry<WorkerRecord>({ dispose: terminate });
-	private readonly service: IpcExtensionsServiceMain;
-	private workerObjectUrl: string | null = null;
-
+export default class WebExtensionManager extends WorkerExtensionManager<null> {
 	constructor(service: IpcExtensionsServiceMain) {
-		this.service = service;
-	}
-
-	async resetProject(projectId: string): Promise<void> {
-		await this.registry.resetProject(projectId);
-	}
-
-	async load(projectId: string, extensionPath: string): Promise<LoadedExtension> {
-		const manifests = new ExtensionManifests(getRuntime().providers);
-		const manifest = await manifests.parse(extensionPath);
-		const fs = getRuntime().p.node.fs.promises;
-		const sourceRaw = await fs.readFile(manifest.scriptPath, 'utf8');
-		const userSource = typeof sourceRaw === 'string' ? sourceRaw : new TextDecoder().decode(sourceRaw as Uint8Array);
-
-		const worker = new Worker(this.getWorkerObjectUrl(), { name: `beak-ext:${manifest.packageName}` });
-
-		const record: WorkerRecord = {
-			worker,
-			loaded: {
-				status: 'loaded',
-				packageName: manifest.packageName,
-				version: manifest.version,
-				displayName: manifest.displayName,
-				description: manifest.description,
-				author: manifest.author,
-				homepage: manifest.homepage,
-				filePath: extensionPath,
-				apiVersion: 1,
-				variables: [],
+		super({
+			providers: getRuntime().providers,
+			workerProvider: new WebWorkerProvider(),
+			callbacks: {
+				parseValueSections: (_callerCtx, varCtx, parts, recursiveDepth) =>
+					parseValueSectionsViaWebIpc(service, varCtx, parts, recursiveDepth),
+				log: (packageName, level, message) => {
+					const logger = getRuntime().p.logger as unknown as Record<string, (m: string) => void>;
+					(logger[level] ?? logger.warn)(`[${packageName}] ${message}`);
+				},
 			},
-			pendingCalls: new Map(),
-		};
-
-		const metadata = await this.initWorker(worker, userSource, manifest.packageName);
-
-		record.loaded.variables = metadata.map(meta => ({
-			...meta,
-			type: makeFullyQualifiedType(manifest.packageName, meta.variableId),
-		}));
-
-		this.attachWorkerListener(record);
-
-		await this.registry.insert(projectId, manifest.packageName, record);
-
-		return record.loaded;
+		});
 	}
+}
 
-	async unload(projectId: string, packageName: string): Promise<void> {
-		await this.registry.unload(projectId, packageName);
-	}
+class WebWorkerProvider implements WorkerProvider {
+	private blobUrl: string | null = null;
 
-	list(projectId: string): Extension[] {
-		return this.registry.list(projectId);
-	}
-
-	/* ---- Variable invocation ------------------------------------------ */
-
-	async variableCreateDefaultPayload(
-		projectId: string,
-		type: string,
-		varCtx: VariableContext,
-	): Promise<Record<string, unknown>> {
-		const { record, variableId } = this.resolve(projectId, type);
-		return (await this.call(record, [variableId, 'createDefaultPayload'], [varCtx])) as Record<string, unknown>;
-	}
-
-	async variableGetValue(
-		projectId: string,
-		type: string,
-		varCtx: VariableContext,
-		payload: unknown,
-		recursiveDepth: number,
-	): Promise<string> {
-		const { record, variableId } = this.resolve(projectId, type);
-		return (await this.call(record, [variableId, 'getValue'], [varCtx, payload, recursiveDepth])) as string;
-	}
-
-	async variableGetAssetRef(
-		projectId: string,
-		type: string,
-		varCtx: VariableContext,
-		payload: unknown,
-		recursiveDepth: number,
-	): Promise<{ sha256: string; size: number; contentType?: string } | null> {
-		const { record, variableId, meta } = this.resolve(projectId, type);
-		if (!meta.binary) return null;
-		return (await this.call(record, [variableId, 'getAssetRef'], [varCtx, payload, recursiveDepth])) as {
-			sha256: string;
-			size: number;
-			contentType?: string;
-		} | null;
-	}
-
-	async variableEditorCreateUI(projectId: string, type: string, varCtx: VariableContext) {
-		const { record, variableId } = this.resolve(projectId, type);
-		return await this.call(record, [variableId, 'editor', 'createUserInterface'], [varCtx]);
-	}
-
-	async variableEditorLoad(projectId: string, type: string, varCtx: VariableContext, payload: unknown) {
-		const { record, variableId } = this.resolve(projectId, type);
-		return await this.call(record, [variableId, 'editor', 'load'], [varCtx, payload]);
-	}
-
-	async variableEditorSave(
-		projectId: string,
-		type: string,
-		varCtx: VariableContext,
-		existingPayload: unknown,
-		state: unknown,
-	) {
-		const { record, variableId } = this.resolve(projectId, type);
-		return await this.call(record, [variableId, 'editor', 'save'], [varCtx, existingPayload, state]);
-	}
-
-	/* ---- Internals ----------------------------------------------------- */
-
-	private resolve(
-		projectId: string,
-		type: string,
-	): { record: WorkerRecord; variableId: string; meta: ExtensionVariable } {
-		const packageName = packageNameFromType(type);
-		const variableId = variableIdFromType(type);
-		const record = this.registry.byPackage(projectId, packageName);
-		const meta = record?.loaded.variables.find(v => v.variableId === variableId);
-
-		if (!record || !meta) throw new Squawk('unknown_registered_extension', { projectId, type });
-
-		return { record, variableId, meta };
-	}
-
-	private getWorkerObjectUrl(): string {
-		if (!this.workerObjectUrl) {
+	spawn(name: string): UnifiedWorker {
+		if (!this.blobUrl) {
 			const blob = new Blob([WORKER_SOURCE], { type: 'application/javascript' });
-			this.workerObjectUrl = URL.createObjectURL(blob);
+			this.blobUrl = URL.createObjectURL(blob);
 		}
 
-		return this.workerObjectUrl;
-	}
-
-	private async initWorker(worker: Worker, userSource: string, packageName: string): Promise<ExtensionVariable[]> {
-		return await new Promise<ExtensionVariable[]>((resolve, reject) => {
-			const timer = setTimeout(() => {
-				worker.terminate();
-				reject(new Squawk('extension_init_timeout', { packageName, timeoutMs: INIT_TIMEOUT_MS }));
-			}, INIT_TIMEOUT_MS);
-
-			const onInit = (event: MessageEvent) => {
-				const data = event.data as { kind: string };
-				if (data.kind === 'init-ok') {
-					clearTimeout(timer);
-					worker.removeEventListener('message', onInit);
-					resolve((data as unknown as { metadata: ExtensionVariable[] }).metadata);
-					return;
-				}
-				if (data.kind === 'init-error') {
-					clearTimeout(timer);
-					worker.removeEventListener('message', onInit);
-					const err = (data as unknown as { error: { code: string; message: string; info?: unknown } }).error;
-					worker.terminate();
-					reject(
-						new Squawk(err.code, { ...((err.info as Record<string, unknown>) ?? {}), message: err.message, packageName }),
-					);
-				}
-			};
-
-			worker.addEventListener('message', onInit);
-			worker.postMessage({ kind: 'init', userSource, packageName });
-		});
-	}
-
-	private attachWorkerListener(record: WorkerRecord) {
-		const service = this.service;
-
-		record.worker.addEventListener('message', async event => {
-			const message = event.data as { kind: string; [k: string]: unknown };
-
-			// `init-*` messages are owned by `initWorker` — anything that
-			// arrives here (e.g. from a misbehaving worker that emits late)
-			// is dropped on the floor; the manager is already past init.
-			if (message.kind === 'init-ok' || message.kind === 'init-error') return;
-
-			if (message.kind === 'result' || message.kind === 'error') {
-				const callId = message.callId as string;
-				const pending = record.pendingCalls.get(callId);
-				if (!pending) return;
-				record.pendingCalls.delete(callId);
-				if (message.kind === 'result') pending.resolve((message as unknown as { value: unknown }).value);
-				else pending.reject(deserialiseWorkerError(message.error as WorkerErrorEnvelope));
-				return;
-			}
-
-			if (message.kind === 'parse-value-sections') {
-				const requestId = message.requestId as string;
-				const ctx = message.ctx as VariableContext;
-				const parts = message.parts as ValueSections;
-
-				// Forward the recursion request to the renderer (same JS process on
-				// the web, but the IPC layer is still where the parser lives).
-				const uniqueSessionId = ksuid.generate('rtvparsersp').toString();
-
-				const listener = (_event: unknown, raw: unknown) => {
-					const incoming = raw as IpcMessage<VariableParseValueSectionsResponse>;
-					if (incoming.code !== ExtensionsMessages.VariableParseValueSectionsResponse) return;
-					if (incoming.payload.uniqueSessionId !== uniqueSessionId) return;
-
-					clearTimeout(responseTimeout);
-					webIpcMain.off('extensions', listener);
-					record.worker.postMessage({
-						kind: 'parse-value-sections-result',
-						requestId,
-						parsed: incoming.payload.parsed,
-					});
-				};
-
-				const responseTimeout = setTimeout(() => {
-					webIpcMain.off('extensions', listener);
-					record.worker.postMessage({
-						kind: 'parse-value-sections-error',
-						requestId,
-						error: { code: 'parse_value_sections_timeout', message: 'renderer did not respond in time' },
-					});
-				}, CALL_TIMEOUT_MS);
-
-				webIpcMain.on('extensions', listener);
-
-				service.variableParseValueSections(webIpcMain.webContents, {
-					uniqueSessionId,
-					context: ctx,
-					parts,
-					recursiveDepth: 0,
-				});
-				return;
-			}
-
-			if (message.kind === 'log') {
-				const level = (message.level as string) || 'info';
-				const text = `[${message.packageName}] ${message.message}`;
-				const logger = getRuntime().p.logger as unknown as Record<string, (m: string) => void>;
-				(logger[level] ?? logger.warn)(text);
-				return;
-			}
-		});
-	}
-
-	private async call(record: WorkerRecord, path: string[], args: unknown[]): Promise<unknown> {
-		const callId = ksuid.generate('extcall').toString();
-
-		return await new Promise((resolve, reject) => {
-			const timer = setTimeout(() => {
-				record.pendingCalls.delete(callId);
-				reject(new Squawk('extension_call_timeout', { path, timeoutMs: CALL_TIMEOUT_MS }));
-			}, CALL_TIMEOUT_MS);
-
-			record.pendingCalls.set(callId, {
-				resolve: value => {
-					clearTimeout(timer);
-					resolve(value);
-				},
-				reject: error => {
-					clearTimeout(timer);
-					reject(error);
-				},
-			});
-
-			record.worker.postMessage({ kind: 'call', callId, path, args });
-		});
+		const worker = new Worker(this.blobUrl, { name });
+		return new WebWorkerAdapter(worker);
 	}
 }
 
-/* -------------------------------------------------------------------------- */
-/*  Helpers                                                                   */
-/* -------------------------------------------------------------------------- */
+class WebWorkerAdapter implements UnifiedWorker {
+	constructor(private readonly worker: Worker) {}
 
-interface WorkerErrorEnvelope {
-	code?: string;
-	message?: string;
-	info?: unknown;
+	postMessage(message: unknown): void {
+		this.worker.postMessage(message);
+	}
+
+	onMessage(listener: (message: unknown) => void): () => void {
+		const handler = (event: MessageEvent) => listener(event.data);
+		this.worker.addEventListener('message', handler);
+		return () => this.worker.removeEventListener('message', handler);
+	}
+
+	onError(listener: (error: unknown) => void): () => void {
+		const handler = (event: ErrorEvent) => listener(event.error ?? event.message);
+		this.worker.addEventListener('error', handler);
+		return () => this.worker.removeEventListener('error', handler);
+	}
+
+	terminate(): void {
+		this.worker.terminate();
+	}
 }
 
-function deserialiseWorkerError(error?: WorkerErrorEnvelope): Squawk {
-	return new Squawk(error?.code ?? 'extension_runtime_error', {
-		message: error?.message ?? 'unknown error',
-		info: error?.info,
+/**
+ * Send a `parseValueSections` request to the renderer via the
+ * extensions IPC channel and await the correlated response. Times out
+ * after `PARSE_VALUE_SECTIONS_TIMEOUT_MS` — the SDK contract is "this
+ * resolves eventually or surfaces an error", never "hangs forever".
+ */
+function parseValueSectionsViaWebIpc(
+	service: IpcExtensionsServiceMain,
+	varCtx: VariableContext,
+	parts: ValueSections,
+	recursiveDepth: number,
+): Promise<string> {
+	const uniqueSessionId = ksuid.generate('rtvparsersp').toString();
+
+	return new Promise<string>((resolve, reject) => {
+		const listener = (_event: unknown, raw: unknown) => {
+			const incoming = raw as IpcMessage<VariableParseValueSectionsResponse>;
+			if (incoming.code !== ExtensionsMessages.VariableParseValueSectionsResponse) return;
+			if (incoming.payload.uniqueSessionId !== uniqueSessionId) return;
+
+			cleanup();
+			resolve(incoming.payload.parsed);
+		};
+
+		const timer = setTimeout(() => {
+			cleanup();
+			reject(new Squawk('parse_value_sections_timeout', { uniqueSessionId, timeoutMs: PARSE_VALUE_SECTIONS_TIMEOUT_MS }));
+		}, PARSE_VALUE_SECTIONS_TIMEOUT_MS);
+
+		function cleanup() {
+			clearTimeout(timer);
+			webIpcMain.off('extensions', listener);
+		}
+
+		webIpcMain.on('extensions', listener);
+
+		service.variableParseValueSections(webIpcMain.webContents, {
+			uniqueSessionId,
+			context: varCtx,
+			parts,
+			recursiveDepth,
+		});
 	});
-}
-
-function terminate(record: WorkerRecord): void {
-	try {
-		record.worker.terminate();
-	} catch {
-		/* already terminated */
-	}
-
-	for (const pending of record.pendingCalls.values()) {
-		pending.reject(new Squawk('extension_terminated', {}));
-	}
-	record.pendingCalls.clear();
 }
 
 export function getExtensionsDir(projectFolderPath: string): string {

--- a/apps-host/web/src/lib/extension/manager.ts
+++ b/apps-host/web/src/lib/extension/manager.ts
@@ -79,7 +79,7 @@ class WebWorkerAdapter implements UnifiedWorker {
 		return () => this.worker.removeEventListener('error', handler);
 	}
 
-	terminate(): void {
+	async terminate(): Promise<void> {
 		this.worker.terminate();
 	}
 }

--- a/docs/adr/0003-unified-worker-extensions.md
+++ b/docs/adr/0003-unified-worker-extensions.md
@@ -117,28 +117,46 @@ The host passes a `callerCtx` through each variable-invocation method
 so the manager can hand it back on the parseValueSections callback —
 that's how Electron picks the right `webContents` per recursive call.
 
-### 3. Trust model — unchanged, made explicit
+### 3. Trust model — match the previous `isolated-vm` tightness
 
-Extensions are installed by the user (manifest validated by
-`@beak/runtime-shared`'s `ExtensionManifests.parse`). The sandbox
-exists to:
+Extensions are installed by the user under a project's `extensions/`
+folder. The sandbox exists to:
 
 - Stop one extension's bug or memory leak from crashing the host.
-- Prevent direct DOM / file-system / shared-state access from
-  extension code.
+- Prevent any host capability (filesystem, network, shared state)
+  from leaking into extension code without going through `extCtx`.
 - Enforce timeouts (`extension_init_timeout` 5s,
   `extension_call_timeout` 30s).
 
-It does **not** position against actively malicious code. Both
-Workers (Web and Node) provide V8-isolate-level memory separation —
-identical to `isolated-vm`'s memory-isolation guarantee. Node
-`worker_threads` does expose `globalThis.Buffer` / `globalThis.process`
-to the worker's main scope, and dynamic `import()` resolves Node
-built-ins. We accept this for now — extensions are installed
-explicitly via the project's `extensions/` folder, not arbitrary
-internet payloads. If a tighter sandbox is needed later, wrap the
-`userSource` evaluation in `vm.runInContext` with a stripped global —
-that's an internal change to `WORKER_SOURCE`, no SDK impact.
+The previous `isolated-vm` implementation ran extension code in a
+fresh V8 isolate whose global scope held only the ECMAScript built-ins
+— no `process`, `Buffer`, `require`, `fetch`, `setTimeout`, nothing
+from Node or the DOM. The unified Worker design **preserves that
+tightness on the Electron side**, and best-effort on the Web side:
+
+- **Electron host (Node `worker_threads`)** — the runtime shim
+  prepended to `WORKER_SOURCE` builds a `vm.createContext` with a
+  hand-curated ECMAScript-only global (Object, Array, Promise, Math,
+  Date, JSON, RegExp, the typed-array family, Reflect, Proxy, Intl,
+  Error and its subclasses, the parse/encode/decode helpers, plus
+  `Function` — which is sandboxed by the vm context). `codeGeneration:
+  { strings: false, wasm: false }` blocks `eval` and dynamic WASM.
+  `userSource` is evaluated via `vm.runInContext`; the resulting
+  `module.exports` lands back in the worker's outer scope where the
+  validate-and-bind pass wires `extCtx` and the per-variable handles.
+  No dynamic `import()`, no `globalThis.process`, no `require` —
+  identical to the `isolated-vm` posture.
+
+- **Web host (Web Worker)** — Web Workers don't have a `vm`-style
+  context API; `new Function` inside the worker runs in the worker's
+  globalThis, which still exposes `fetch`, `crypto`, `setTimeout`,
+  `URL`, etc. We accept this as a known asymmetry. Tightening the
+  web side properly needs either the Realms API (Stage 3, not widely
+  shipped) or iframe-based sandboxes (heavyweight, separate origin
+  story). Out of scope for this ADR; tracked as a follow-up.
+
+Memory isolation in both runtimes is identical to `isolated-vm` —
+each worker is its own V8 isolate with its own heap.
 
 ### 4. SDK contract — frozen at apiVersion: 1
 

--- a/docs/adr/0003-unified-worker-extensions.md
+++ b/docs/adr/0003-unified-worker-extensions.md
@@ -1,0 +1,188 @@
+# 0003 — Unified Worker-based extension sandbox
+
+- **Status:** Accepted
+- **Date:** 2026-06-08
+- **Deciders:** Alexander Forbes-Reed
+
+## Context
+
+Beak runs untrusted extension code (currently variable contributions:
+`createDefaultPayload`, `getValue`, `getAssetRef`, `editor.*`) inside two
+different sandboxes today:
+
+- **Electron host** — `isolated-vm` (`apps-host/electron/src/lib/extension/index.ts`).
+  Each loaded extension runs in its own V8 isolate via the `ivm.Isolate`
+  + `ivm.Context` API. Native module rebuilt against electron's Node ABI
+  via `electron-rebuild -f -w isolated-vm` in the apps-host/electron
+  postinstall.
+- **Web host** — Web Worker (`apps-host/web/src/lib/extension/manager.ts` +
+  `worker-source.ts`). One Worker per loaded extension; `init` /
+  `call` / `parse-value-sections` message protocol.
+
+The two implementations have identical public surfaces (same method
+names on `ExtensionManager`, same IPC channel, same SDK contract) but
+duplicate the bootstrap, validation, error mapping, and lifecycle code.
+More importantly, `isolated-vm` is the sole reason the Electron build
+needs:
+
+- `electron-rebuild` (postinstall, slow on cold install; needs Python +
+  C++ toolchain on the user's machine for source builds).
+- `pnpm.patchedDependencies` consideration for native ABI compat across
+  electron releases.
+- `app.asar.unpacked` carrying unsigned `.node` binaries +
+  `isolated-vm-X.Y.Z.tgz` + the `prebuilds/` tree → macOS notarization
+  rejection on PR #672's CI.
+- A per-release `afterPack` script to strip those artefacts before
+  signing.
+
+The web host already proved Workers are sufficient: same isolation
+guarantees we actually use (separate V8 heap, separate event loop, no
+shared mutable state, structured-clone-only IPC), same observable
+behaviour for the SDK, no native code.
+
+## Decision
+
+Drop `isolated-vm`. Both hosts run extensions in Workers — Web Workers
+in the browser, `node:worker_threads` in Electron — driven by **one
+shared manager + worker source** in `@beak/runtime-shared/extensions/`.
+
+Per-host code shrinks to a thin adapter: spawn the host's Worker
+primitive with the shared source, route the worker's
+`parse-value-sections` callbacks through the host's IPC layer, and
+forward log messages.
+
+### 1. One worker source, two transports
+
+`packages/runtime-shared/src/extensions/worker-source.ts` exports
+`WORKER_SOURCE` — the existing Web-Worker-style string (`self.addEventListener('message', …)`,
+top-level `postMessage`, `new Function('module', 'exports', userSource)`).
+
+- **Web host** loads it via `new Worker(URL.createObjectURL(blob))` —
+  unchanged from today.
+- **Electron host** prepends a 6-line shim that aliases
+  `self`/`postMessage`/`addEventListener` onto Node's `parentPort`,
+  then runs it via `new Worker(prefixedSource, { eval: true })` from
+  `node:worker_threads`.
+
+The shim:
+
+```js
+const { parentPort } = require('node:worker_threads');
+globalThis.self = globalThis;
+globalThis.postMessage = parentPort.postMessage.bind(parentPort);
+globalThis.addEventListener = (type, fn) => {
+  if (type === 'message') parentPort.on('message', data => fn({ data }));
+};
+```
+
+The user's extension code itself remains identical — same
+`defineExtension({...})` shape, same `extCtx` API, same SDK.
+
+### 2. Unified `WorkerExtensionManager` in runtime-shared
+
+The host-side manager (everything in `WebExtensionManager` today —
+load / unload / call routing / parse-value-sections bridging / error
+serialisation) moves to
+`packages/runtime-shared/src/extensions/worker-manager.ts`,
+parameterised on two collaborators:
+
+```ts
+interface WorkerProvider {
+  /** Spawn a worker that evaluates WORKER_SOURCE. */
+  spawn(name: string): UnifiedWorker;
+}
+
+interface UnifiedWorker {
+  postMessage(msg: unknown): void;
+  onMessage(fn: (msg: unknown) => void): () => void; // unsubscribe
+  onError(fn: (err: unknown) => void): () => void;
+  terminate(): void | Promise<unknown>;
+}
+
+interface ManagerCallbacks {
+  /** Recursive value-section parse — host owns the IPC roundtrip. */
+  parseValueSections(
+    callerCtx: unknown,        // host-specific (webContents for electron, null for web)
+    varCtx: VariableContext,
+    parts: ValueSections,
+    recursiveDepth: number,
+  ): Promise<string>;
+
+  /** Worker log sink — `(packageName, level, message)`. */
+  log(packageName: string, level: string, message: string): void;
+}
+```
+
+The host passes a `callerCtx` through each variable-invocation method
+so the manager can hand it back on the parseValueSections callback —
+that's how Electron picks the right `webContents` per recursive call.
+
+### 3. Trust model — unchanged, made explicit
+
+Extensions are installed by the user (manifest validated by
+`@beak/runtime-shared`'s `ExtensionManifests.parse`). The sandbox
+exists to:
+
+- Stop one extension's bug or memory leak from crashing the host.
+- Prevent direct DOM / file-system / shared-state access from
+  extension code.
+- Enforce timeouts (`extension_init_timeout` 5s,
+  `extension_call_timeout` 30s).
+
+It does **not** position against actively malicious code. Both
+Workers (Web and Node) provide V8-isolate-level memory separation —
+identical to `isolated-vm`'s memory-isolation guarantee. Node
+`worker_threads` does expose `globalThis.Buffer` / `globalThis.process`
+to the worker's main scope, and dynamic `import()` resolves Node
+built-ins. We accept this for now — extensions are installed
+explicitly via the project's `extensions/` folder, not arbitrary
+internet payloads. If a tighter sandbox is needed later, wrap the
+`userSource` evaluation in `vm.runInContext` with a stripped global —
+that's an internal change to `WORKER_SOURCE`, no SDK impact.
+
+### 4. SDK contract — frozen at apiVersion: 1
+
+`@getbeak/extension-sdk` doesn't change. Extensions written against
+the current `defineExtension({...})` keep working. The Worker harness
+validates the same shape the isolated-vm harness validated.
+
+## Consequences
+
+**Wins:**
+
+- `isolated-vm` removed from `apps-host/electron/package.json`
+  (one less native dep, no electron-rebuild for it, faster cold installs).
+- `app.asar.unpacked` no longer contains unsigned prebuilds → macOS
+  notarization stops failing on the existing `.node` binaries.
+- Single source of truth for the extension execution model. New
+  variable contract additions (`getAssetRef`, future binary helpers)
+  ship as one edit to `worker-source.ts` instead of two.
+- The Electron extension manager drops from 467 lines (`isolated-vm`
+  glue, `ivm.Reference.apply` plumbing, `ExternalCopy` ceremony) to
+  ~60 lines (host-specific IPC bridge + WorkerProvider).
+
+**Costs / risks:**
+
+- `worker_threads` is a slightly heavier per-extension footprint than
+  `isolated-vm` — full Node runtime per worker, ~10-20MB RSS each
+  vs. ~3-5MB. Acceptable: a typical project loads 0–3 extensions, the
+  delta is invisible.
+- Workers spawn slower than isolates (50-200ms cold vs. ~10ms). Init
+  is async and already timed-out at 5s; no user-observable change.
+- Sandbox is meaningfully weaker against adversarial code (see
+  Decision §3). Trust model already assumed installed-by-user
+  extensions, so this matches reality.
+
+**Migration:**
+
+1. Land `WORKER_SOURCE` + `WorkerExtensionManager` in `runtime-shared`.
+2. Switch web host to import them (delete `apps-host/web/src/lib/extension/`).
+3. Add Electron WorkerProvider via `node:worker_threads`; delete
+   `apps-host/electron/src/lib/extension/index.ts`'s isolated-vm code.
+4. Remove `isolated-vm` from `apps-host/electron/package.json` deps +
+   the `electron-rebuild -f -w isolated-vm` postinstall script.
+5. Remove any afterPack pruning that was added as a stopgap.
+6. Verify: existing extension tests pass on both hosts; `pnpm package`
+   completes notarization on macOS CI.
+
+No data migration. Extensions on disk are unchanged.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -41,10 +41,11 @@ Do **not** write an ADR for:
 
 ## Index
 
-| #    | Status   | Title                                                                  |
-| ---- | -------- | ---------------------------------------------------------------------- |
-| 0000 | Accepted | [Adopt MADR-style ADRs and Gherkin feature files](0000-adr-process.md) |
-| 0001 | Accepted | [Local agent for the web host](0001-local-agent-for-web-host.md)       |
+| #    | Status   | Title                                                                            |
+| ---- | -------- | -------------------------------------------------------------------------------- |
+| 0000 | Accepted | [Adopt MADR-style ADRs and Gherkin feature files](0000-adr-process.md)           |
+| 0001 | Accepted | [Local agent for the web host](0001-local-agent-for-web-host.md)                 |
+| 0003 | Accepted | [Unified Worker-based extension sandbox](0003-unified-worker-extensions.md)      |
 
 ## Granularity guideline
 

--- a/packages/runtime-shared/src/extensions/__tests__/worker-manager.test.ts
+++ b/packages/runtime-shared/src/extensions/__tests__/worker-manager.test.ts
@@ -1,0 +1,328 @@
+import { promises as fs } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import nodePath, { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Providers } from '../../base';
+import type { UnifiedWorker, WorkerManagerCallbacks, WorkerProvider } from '../worker-manager';
+import { WorkerExtensionManager } from '../worker-manager';
+
+/**
+ * Unit tests for `WorkerExtensionManager`. The worker is stubbed via a fake
+ * `WorkerProvider`/`UnifiedWorker`, so these exercise the manager's wire
+ * handling (init / call / error / log) without spawning a real V8 isolate.
+ *
+ * Sandbox + worker-source behaviour is covered by `worker-source.test.ts`.
+ */
+
+function buildProviders(): Providers {
+	return {
+		// biome-ignore lint/suspicious/noExplicitAny: stubs sufficient for the surface manager.load() touches
+		aes: { algorithmVersionMap: {}, generateKey: async () => 'k' } as any,
+		// biome-ignore lint/suspicious/noExplicitAny: stub
+		credentials: { setProjectEncryption: async () => undefined } as any,
+		// biome-ignore lint/suspicious/noExplicitAny: stub
+		logger: { info: () => {}, error: () => {}, warn: () => {} } as any,
+		// biome-ignore lint/suspicious/noExplicitAny: stub
+		storage: { get: async () => undefined, set: async () => {}, has: async () => false } as any,
+		node: {
+			// biome-ignore lint/suspicious/noExplicitAny: real fs satisfies the narrow surface
+			fs: { promises: fs } as any,
+			// biome-ignore lint/suspicious/noExplicitAny: see above
+			path: nodePath as any,
+		},
+	} as Providers;
+}
+
+class StubWorker implements UnifiedWorker {
+	private messageListeners: Array<(message: unknown) => void> = [];
+	private errorListeners: Array<(error: unknown) => void> = [];
+	terminated = false;
+	postMessageLog: unknown[] = [];
+
+	postMessage(message: unknown): void {
+		this.postMessageLog.push(message);
+	}
+
+	onMessage(listener: (message: unknown) => void): () => void {
+		this.messageListeners.push(listener);
+		return () => {
+			this.messageListeners = this.messageListeners.filter(l => l !== listener);
+		};
+	}
+
+	onError(listener: (error: unknown) => void): () => void {
+		this.errorListeners.push(listener);
+		return () => {
+			this.errorListeners = this.errorListeners.filter(l => l !== listener);
+		};
+	}
+
+	async terminate(): Promise<void> {
+		this.terminated = true;
+	}
+
+	/** Drive a message from the worker to the host. */
+	emit(message: unknown): void {
+		for (const listener of this.messageListeners) listener(message);
+	}
+
+	/** Drive an uncaught error from the worker. */
+	emitError(error: unknown): void {
+		for (const listener of this.errorListeners) listener(error);
+	}
+}
+
+class StubProvider implements WorkerProvider {
+	readonly workers: StubWorker[] = [];
+
+	spawn(_name: string): UnifiedWorker {
+		const worker = new StubWorker();
+		this.workers.push(worker);
+		return worker;
+	}
+}
+
+async function writeFakeExtension(root: string, packageName: string, source = "module.exports = { apiVersion: 1, variables: [] };"): Promise<string> {
+	const folder = join(root, packageName);
+	await fs.mkdir(folder, { recursive: true });
+	await fs.writeFile(
+		join(folder, 'package.json'),
+		JSON.stringify({ name: packageName, version: '1.0.0', main: 'index.js', beak: { apiVersion: 1 } }),
+	);
+	await fs.writeFile(join(folder, 'index.js'), source);
+	return folder;
+}
+
+function makeCallbacks(): WorkerManagerCallbacks<null> {
+	return {
+		parseValueSections: vi.fn(async () => 'parsed'),
+		log: vi.fn(),
+	};
+}
+
+/**
+ * `manager.load()` does an async manifest parse + script read before it
+ * spawns the worker. Tests need to drain the microtask queue a few times
+ * before the stub worker is visible.
+ */
+async function waitForWorker(provider: StubProvider, index = 0): Promise<StubWorker> {
+	for (let i = 0; i < 50; i++) {
+		const worker = provider.workers[index];
+		if (worker) return worker;
+		await new Promise(resolve => setImmediate(resolve));
+	}
+	throw new Error(`worker[${index}] never spawned`);
+}
+
+const FAKE_METADATA = [
+	{
+		variableId: 'v',
+		name: 'V',
+		description: 'd',
+		sensitive: false,
+		keywords: [],
+		attributes: { requiresRequestId: false },
+		editable: false,
+		binary: false,
+	},
+];
+
+async function loadDemo(provider: StubProvider, manager: WorkerExtensionManager<null>, folder: string): Promise<StubWorker> {
+	const pending = manager.load('p1', folder);
+	const worker = await waitForWorker(provider);
+	worker.emit({ kind: 'init-ok', metadata: FAKE_METADATA });
+	await pending;
+	return worker;
+}
+
+let workdir: string;
+
+beforeEach(async () => {
+	workdir = await mkdtemp(join(tmpdir(), 'wem-'));
+});
+
+afterEach(async () => {
+	await rm(workdir, { recursive: true, force: true });
+});
+
+describe('WorkerExtensionManager.load', () => {
+	it('spawns a worker, posts the init message, and resolves with the loaded surface', async () => {
+		const folder = await writeFakeExtension(workdir, 'demo');
+		const provider = new StubProvider();
+		const manager = new WorkerExtensionManager<null>({
+			providers: buildProviders(),
+			workerProvider: provider,
+			callbacks: makeCallbacks(),
+		});
+
+		const pending = manager.load('p1', folder);
+		const worker = await waitForWorker(provider);
+		expect(worker.postMessageLog).toEqual([expect.objectContaining({ kind: 'init', packageName: 'demo' })]);
+
+		worker.emit({ kind: 'init-ok', metadata: FAKE_METADATA });
+		const loaded = await pending;
+
+		expect(loaded.packageName).toBe('demo');
+		expect(loaded.variables).toHaveLength(1);
+		expect(loaded.variables[0].type).toBe('external:demo/v');
+	});
+
+	it('rejects with the worker-reported error code when init-error arrives', async () => {
+		const folder = await writeFakeExtension(workdir, 'broken');
+		const provider = new StubProvider();
+		const manager = new WorkerExtensionManager<null>({
+			providers: buildProviders(),
+			workerProvider: provider,
+			callbacks: makeCallbacks(),
+		});
+
+		const pending = manager.load('p1', folder);
+		const worker = await waitForWorker(provider);
+		worker.emit({ kind: 'init-error', error: { code: 'extension_no_variables', message: 'none' } });
+
+		await expect(pending).rejects.toMatchObject({ code: 'extension_no_variables' });
+	});
+});
+
+describe('WorkerExtensionManager.variable*', () => {
+	it('routes getValue → posts call to worker → resolves with the worker result', async () => {
+		const folder = await writeFakeExtension(workdir, 'demo');
+		const provider = new StubProvider();
+		const manager = new WorkerExtensionManager<null>({
+			providers: buildProviders(),
+			workerProvider: provider,
+			callbacks: makeCallbacks(),
+		});
+
+		const worker = await loadDemo(provider, manager, folder);
+		const callPending = manager.variableGetValue('p1', 'external:demo/v', {} as never, null, { p: 1 }, 0);
+		const callMessage = worker.postMessageLog[worker.postMessageLog.length - 1] as { kind: string; callId: string; path: string[]; args: unknown[] };
+		expect(callMessage.kind).toBe('call');
+		expect(callMessage.path).toEqual(['v', 'getValue']);
+		expect(callMessage.args).toEqual([{}, { p: 1 }, 0]);
+
+		worker.emit({ kind: 'result', callId: callMessage.callId, value: 'forty-two' });
+		await expect(callPending).resolves.toBe('forty-two');
+	});
+
+	it('rejects on a worker error message with the Squawk shape', async () => {
+		const folder = await writeFakeExtension(workdir, 'demo');
+		const provider = new StubProvider();
+		const manager = new WorkerExtensionManager<null>({
+			providers: buildProviders(),
+			workerProvider: provider,
+			callbacks: makeCallbacks(),
+		});
+
+		const worker = await loadDemo(provider, manager, folder);
+		const callPending = manager.variableGetValue('p1', 'external:demo/v', {} as never, null, {}, 0);
+		const callId = (worker.postMessageLog[worker.postMessageLog.length - 1] as { callId: string }).callId;
+		worker.emit({ kind: 'error', callId, error: { code: 'extension_custom_error', message: 'nope' } });
+
+		await expect(callPending).rejects.toMatchObject({ code: 'extension_custom_error' });
+	});
+
+	it('throws unknown_registered_extension for an unloaded type', async () => {
+		const manager = new WorkerExtensionManager<null>({
+			providers: buildProviders(),
+			workerProvider: new StubProvider(),
+			callbacks: makeCallbacks(),
+		});
+
+		await expect(
+			manager.variableGetValue('nobody', 'external:ghost/x', {} as never, null, {}, 0),
+		).rejects.toMatchObject({ code: 'unknown_registered_extension' });
+	});
+
+	it('returns null for getAssetRef on a non-binary variable without posting to the worker', async () => {
+		const folder = await writeFakeExtension(workdir, 'demo');
+		const provider = new StubProvider();
+		const manager = new WorkerExtensionManager<null>({
+			providers: buildProviders(),
+			workerProvider: provider,
+			callbacks: makeCallbacks(),
+		});
+
+		const worker = await loadDemo(provider, manager, folder);
+		const before = worker.postMessageLog.length;
+		const result = await manager.variableGetAssetRef('p1', 'external:demo/v', {} as never, null, {}, 0);
+		expect(result).toBeNull();
+		expect(worker.postMessageLog.length).toBe(before);
+	});
+});
+
+describe('WorkerExtensionManager — lifecycle', () => {
+	it('unload terminates the worker and rejects any in-flight calls', async () => {
+		const folder = await writeFakeExtension(workdir, 'demo');
+		const provider = new StubProvider();
+		const manager = new WorkerExtensionManager<null>({
+			providers: buildProviders(),
+			workerProvider: provider,
+			callbacks: makeCallbacks(),
+		});
+
+		const worker = await loadDemo(provider, manager, folder);
+		const callPending = manager.variableGetValue('p1', 'external:demo/v', {} as never, null, {}, 0);
+		await manager.unload('p1', 'demo');
+
+		expect(worker.terminated).toBe(true);
+		await expect(callPending).rejects.toMatchObject({ code: 'extension_terminated' });
+	});
+
+	it('worker onError rejects pending calls without waiting for the call timeout', async () => {
+		const folder = await writeFakeExtension(workdir, 'demo');
+		const provider = new StubProvider();
+		const manager = new WorkerExtensionManager<null>({
+			providers: buildProviders(),
+			workerProvider: provider,
+			callbacks: makeCallbacks(),
+		});
+
+		const worker = await loadDemo(provider, manager, folder);
+		const callPending = manager.variableGetValue('p1', 'external:demo/v', {} as never, null, {}, 0);
+		worker.emitError(new Error('runtime exploded'));
+
+		await expect(callPending).rejects.toMatchObject({ code: 'extension_worker_error' });
+	});
+
+	it('forwards log messages from the worker through the host callback', async () => {
+		const folder = await writeFakeExtension(workdir, 'demo');
+		const provider = new StubProvider();
+		const callbacks = makeCallbacks();
+		const manager = new WorkerExtensionManager<null>({
+			providers: buildProviders(),
+			workerProvider: provider,
+			callbacks,
+		});
+
+		const worker = await loadDemo(provider, manager, folder);
+		worker.emit({ kind: 'log', packageName: 'demo', level: 'info', message: 'hello' });
+		expect(callbacks.log).toHaveBeenCalledWith('demo', 'info', 'hello');
+	});
+
+	it('parseValueSections from the worker round-trips back via the host callback', async () => {
+		const folder = await writeFakeExtension(workdir, 'demo');
+		const provider = new StubProvider();
+		const callbacks = makeCallbacks();
+		(callbacks.parseValueSections as ReturnType<typeof vi.fn>).mockResolvedValue('parsed-result');
+		const manager = new WorkerExtensionManager<null>({
+			providers: buildProviders(),
+			workerProvider: provider,
+			callbacks,
+		});
+
+		const worker = await loadDemo(provider, manager, folder);
+		// Pretend we're mid-call so callerCtxByWorker is set.
+		void manager.variableGetValue('p1', 'external:demo/v', {} as never, null, {}, 0);
+		worker.emit({ kind: 'parse-value-sections', requestId: 'r1', ctx: {}, parts: ['lit'] });
+		// Drain microtasks so the async callback can fire + the manager can post back.
+		await new Promise(resolve => setImmediate(resolve));
+		expect(callbacks.parseValueSections).toHaveBeenCalled();
+
+		const lastPosted = worker.postMessageLog[worker.postMessageLog.length - 1] as { kind: string; requestId: string; parsed: string };
+		expect(lastPosted).toEqual({ kind: 'parse-value-sections-result', requestId: 'r1', parsed: 'parsed-result' });
+	});
+});

--- a/packages/runtime-shared/src/extensions/__tests__/worker-source.test.ts
+++ b/packages/runtime-shared/src/extensions/__tests__/worker-source.test.ts
@@ -1,0 +1,237 @@
+import { Worker } from 'node:worker_threads';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+import { WORKER_RUNTIME_NODE_SHIM, WORKER_SOURCE } from '../worker-source';
+
+/**
+ * End-to-end exercises of `WORKER_SOURCE` running under `node:worker_threads`
+ * — the production Electron path. Each test spins up a fresh worker, drives
+ * the wire protocol (`init` / `call`), and asserts the worker's behaviour.
+ *
+ * The sandbox tests double as the regression net for ADR-0003 §3: every
+ * vector that escaped during the drive-security audit lives here.
+ */
+
+const FULL_SOURCE = `${WORKER_RUNTIME_NODE_SHIM}\n${WORKER_SOURCE}`;
+
+interface WorkerSession {
+	worker: Worker;
+	dispose: () => Promise<void>;
+}
+
+const sessions: WorkerSession[] = [];
+
+function spawnWorker(): WorkerSession {
+	const worker = new Worker(FULL_SOURCE, { eval: true, name: 'wsrc-test' });
+	const session: WorkerSession = {
+		worker,
+		dispose: async () => {
+			worker.removeAllListeners();
+			await worker.terminate();
+		},
+	};
+	sessions.push(session);
+	return session;
+}
+
+afterAll(async () => {
+	await Promise.all(sessions.map(s => s.dispose()));
+});
+
+async function initAndCall(userSource: string): Promise<{ initOk: boolean; metadata?: unknown; error?: unknown; result?: unknown }> {
+	const { worker } = spawnWorker();
+	return await new Promise(resolve => {
+		const collected: { initOk: boolean; metadata?: unknown; error?: unknown; result?: unknown } = { initOk: false };
+		worker.on('message', message => {
+			if (message.kind === 'init-ok') {
+				collected.initOk = true;
+				collected.metadata = message.metadata;
+				worker.postMessage({ kind: 'call', callId: 'c1', path: ['probe', 'getValue'], args: [{}, {}, 0] });
+				return;
+			}
+			if (message.kind === 'init-error') {
+				collected.initOk = false;
+				collected.error = message.error;
+				resolve(collected);
+				return;
+			}
+			if (message.kind === 'result') {
+				collected.result = message.value;
+				resolve(collected);
+				return;
+			}
+			if (message.kind === 'error') {
+				collected.error = message.error;
+				resolve(collected);
+			}
+		});
+		worker.on('error', err => {
+			collected.error = { code: 'worker_error', message: err instanceof Error ? err.message : String(err) };
+			resolve(collected);
+		});
+		worker.postMessage({ kind: 'init', userSource, packageName: 'test-pkg' });
+	});
+}
+
+const probeExtension = `
+module.exports = {
+	apiVersion: 1,
+	variables: [{
+		id: 'probe',
+		name: 'Probe',
+		description: 'Reach for things the sandbox should block.',
+		createDefaultPayload: () => ({}),
+		getValue: () => {
+			const r = {};
+			const t = (label, fn) => { try { r[label] = fn(); } catch (e) { r[label] = 'T:' + (e.message || String(e)); } };
+			t('process', () => typeof process);
+			t('require', () => typeof require);
+			t('Buffer', () => typeof Buffer);
+			t('console', () => typeof console);
+			t('Atomics', () => typeof Atomics);
+			t('SharedArrayBuffer', () => typeof SharedArrayBuffer);
+			t('WebAssembly', () => typeof WebAssembly);
+			t('eval', () => typeof eval);
+			t('setTimeout', () => typeof setTimeout);
+			t('fetch', () => typeof fetch);
+			t('via_module_ctor', () => typeof module.constructor.constructor('return process')());
+			t('via_exports_ctor', () => typeof exports.constructor.constructor('return process')());
+			t('via_Function', () => typeof Function('return process')());
+			t('via_obj_ctor', () => typeof ({}).constructor.constructor('return process')());
+			t('via_promise_ctor', () => typeof Promise.resolve(0).constructor.constructor('return process')());
+			t('via_globalThis', () => typeof globalThis.process);
+			t('via_wasm', () => { new WebAssembly.Module(new Uint8Array([0,97,115,109,1,0,0,0])); return 'ALLOWED'; });
+			return JSON.stringify(r);
+		}
+	}]
+};
+`;
+
+describe('WORKER_SOURCE — sandbox properties', () => {
+	it('strips Node + Web platform globals reachable by name', async () => {
+		const outcome = await initAndCall(probeExtension);
+		expect(outcome.initOk).toBe(true);
+		const r = JSON.parse(outcome.result as string) as Record<string, string>;
+		expect(r.process).toBe('undefined');
+		expect(r.require).toBe('undefined');
+		expect(r.Buffer).toBe('undefined');
+		expect(r.console).toBe('undefined');
+		expect(r.Atomics).toBe('undefined');
+		expect(r.SharedArrayBuffer).toBe('undefined');
+		expect(r.WebAssembly).toBe('undefined');
+		expect(r.eval).toBe('undefined');
+		expect(r.setTimeout).toBe('undefined');
+		expect(r.fetch).toBe('undefined');
+		expect(r.via_globalThis).toBe('undefined');
+	});
+
+	it('blocks Function-constructor escape via outer-realm primordials', async () => {
+		const outcome = await initAndCall(probeExtension);
+		expect(outcome.initOk).toBe(true);
+		const r = JSON.parse(outcome.result as string) as Record<string, string>;
+		// Every "walk to outer Function and call it" path must throw under
+		// `codeGeneration: { strings: false }`. Bug here = ADR-0003 §3
+		// regression.
+		expect(r.via_module_ctor).toMatch(/Code generation from strings disallowed/);
+		expect(r.via_exports_ctor).toMatch(/Code generation from strings disallowed/);
+		expect(r.via_Function).toMatch(/Code generation from strings disallowed/);
+		expect(r.via_obj_ctor).toMatch(/Code generation from strings disallowed/);
+		expect(r.via_promise_ctor).toMatch(/Code generation from strings disallowed/);
+	});
+
+	it('blocks WebAssembly.compile / Module construction', async () => {
+		const outcome = await initAndCall(probeExtension);
+		expect(outcome.initOk).toBe(true);
+		const r = JSON.parse(outcome.result as string) as Record<string, string>;
+		// WebAssembly itself is deleted from the sandbox globals; the
+		// `codeGeneration.wasm: false` flag would block compile too.
+		expect(r.via_wasm).toBe('T:WebAssembly is not defined');
+	});
+});
+
+describe('WORKER_SOURCE — validation', () => {
+	it('rejects an extension that does not export defineExtension', async () => {
+		const outcome = await initAndCall('module.exports = 42;');
+		expect(outcome.initOk).toBe(false);
+		expect((outcome.error as { code: string }).code).toBe('extension_invalid_export');
+	});
+
+	it('rejects an unsupported apiVersion', async () => {
+		const outcome = await initAndCall(
+			'module.exports = { apiVersion: 999, variables: [{ id: "x", name: "X", description: "x", createDefaultPayload: () => ({}), getValue: () => "x" }] };',
+		);
+		expect(outcome.initOk).toBe(false);
+		expect((outcome.error as { code: string }).code).toBe('extension_unsupported_api_version');
+	});
+
+	it('rejects when the extension contributes no variables', async () => {
+		const outcome = await initAndCall('module.exports = { apiVersion: 1, variables: [] };');
+		expect(outcome.initOk).toBe(false);
+		expect((outcome.error as { code: string }).code).toBe('extension_no_variables');
+	});
+
+	it('rejects a variable missing its id', async () => {
+		const outcome = await initAndCall(
+			'module.exports = { apiVersion: 1, variables: [{ name: "x", description: "d", createDefaultPayload: () => ({}), getValue: () => "x" }] };',
+		);
+		expect(outcome.initOk).toBe(false);
+		expect((outcome.error as { code: string }).code).toBe('extension_variable_missing_id');
+	});
+
+	it('rejects an editor block without createUserInterface', async () => {
+		const outcome = await initAndCall(
+			'module.exports = { apiVersion: 1, variables: [{ id: "x", name: "X", description: "d", createDefaultPayload: () => ({}), getValue: () => "x", editor: { load: () => ({}) } }] };',
+		);
+		expect(outcome.initOk).toBe(false);
+		expect((outcome.error as { code: string }).code).toBe('extension_editor_incomplete');
+	});
+
+	it('init-ok returns the variable metadata shape the host expects', async () => {
+		const outcome = await initAndCall(
+			`module.exports = {
+				apiVersion: 1,
+				variables: [{
+					id: 'pingvar',
+					name: 'Ping',
+					description: 'returns pong',
+					sensitive: true,
+					keywords: ['p', 'q'],
+					createDefaultPayload: () => ({}),
+					getValue: () => 'pong',
+					getAssetRef: () => null,
+				}],
+			};`,
+		);
+		expect(outcome.initOk).toBe(true);
+		const metadata = outcome.metadata as Array<Record<string, unknown>>;
+		expect(metadata).toHaveLength(1);
+		expect(metadata[0]).toMatchObject({
+			variableId: 'pingvar',
+			name: 'Ping',
+			description: 'returns pong',
+			sensitive: true,
+			keywords: ['p', 'q'],
+			editable: false,
+			binary: true, // getAssetRef present
+		});
+	});
+});
+
+describe('WORKER_SOURCE — happy path', () => {
+	it('routes a getValue call through the worker and returns the value', async () => {
+		const outcome = await initAndCall(
+			"module.exports = { apiVersion: 1, variables: [{ id: 'probe', name: 'P', description: 'd', createDefaultPayload: () => ({}), getValue: () => 'pong' }] };",
+		);
+		expect(outcome.initOk).toBe(true);
+		expect(outcome.result).toBe('pong');
+	});
+
+	it('propagates errors thrown inside getValue back to the host', async () => {
+		const outcome = await initAndCall(
+			"module.exports = { apiVersion: 1, variables: [{ id: 'probe', name: 'P', description: 'd', createDefaultPayload: () => ({}), getValue: () => { throw new Error('boom'); } }] };",
+		);
+		expect(outcome.initOk).toBe(true);
+		expect((outcome.error as { message: string }).message).toMatch(/boom/);
+	});
+});

--- a/packages/runtime-shared/src/extensions/index.ts
+++ b/packages/runtime-shared/src/extensions/index.ts
@@ -15,3 +15,11 @@ export type { RegisteredRecord, RegistryOptions } from './registry-base';
 export { ProjectExtensionRegistry } from './registry-base';
 export type { TarEntry } from './tar';
 export { gunzip, readTar } from './tar';
+export { WORKER_SOURCE, WORKER_RUNTIME_NODE_SHIM } from './worker-source';
+export type {
+	UnifiedWorker,
+	WorkerExtensionManagerOptions,
+	WorkerManagerCallbacks,
+	WorkerProvider,
+} from './worker-manager';
+export { WorkerExtensionManager } from './worker-manager';

--- a/packages/runtime-shared/src/extensions/index.ts
+++ b/packages/runtime-shared/src/extensions/index.ts
@@ -15,7 +15,6 @@ export type { RegisteredRecord, RegistryOptions } from './registry-base';
 export { ProjectExtensionRegistry } from './registry-base';
 export type { TarEntry } from './tar';
 export { gunzip, readTar } from './tar';
-export { WORKER_SOURCE, WORKER_RUNTIME_NODE_SHIM } from './worker-source';
 export type {
 	UnifiedWorker,
 	WorkerExtensionManagerOptions,
@@ -23,3 +22,4 @@ export type {
 	WorkerProvider,
 } from './worker-manager';
 export { WorkerExtensionManager } from './worker-manager';
+export { WORKER_RUNTIME_NODE_SHIM, WORKER_SOURCE } from './worker-source';

--- a/packages/runtime-shared/src/extensions/registry-base.ts
+++ b/packages/runtime-shared/src/extensions/registry-base.ts
@@ -1,13 +1,11 @@
 import type { Extension, LoadedExtension } from '@beak/common/types/extensions';
 
 /**
- * Per-project, per-package extension record. Each host parameterises the
- * registry with its own concrete shape:
- *   electron → `{ isolate, context, variables, loaded }`
- *   web      → `{ worker, loaded, pendingCalls, variables }`
- *
- * The base only requires a `loaded` field for the management IPC's
- * `list` call — every other shape is opaque.
+ * Per-project, per-package extension record. Both hosts now use the same
+ * Worker-based shape (`WorkerExtensionManager`'s `WorkerRecord`) — see
+ * ADR-0003. The base only requires a `loaded` field for the management
+ * IPC's `list` call — every other shape is opaque so this stays usable
+ * if a third host shape ever appears.
  */
 export interface RegisteredRecord {
 	readonly loaded: LoadedExtension;
@@ -21,15 +19,8 @@ export interface RegistryOptions<TRecord> {
 /**
  * Lifecycle + lookup primitives shared by both extension managers. The
  * registry owns the `Record<projectId, Record<packageName, Record>>`
- * shape; per-host managers consume it for the variable-invocation
- * methods that vary by execution model (isolated-vm vs Worker).
- *
- * Type-to-package resolution is host-owned because the two hosts walk
- * the resolved record differently:
- *   electron looks up `record.variables[fully-qualified-type]`
- *   web looks up by `variableId` derived from the type
- * The registry just hands you the per-package record; the manager
- * extracts whichever per-variable shape it stores there.
+ * shape; the manager (`WorkerExtensionManager`) consumes it for the
+ * variable-invocation methods.
  */
 export class ProjectExtensionRegistry<TRecord extends RegisteredRecord> {
 	private readonly projects: Record<string, Record<string, TRecord>> = {};

--- a/packages/runtime-shared/src/extensions/worker-manager.ts
+++ b/packages/runtime-shared/src/extensions/worker-manager.ts
@@ -38,7 +38,8 @@ export interface UnifiedWorker {
 	postMessage(message: unknown): void;
 	onMessage(listener: (message: unknown) => void): () => void;
 	onError(listener: (error: unknown) => void): () => void;
-	terminate(): void | Promise<unknown>;
+	/** Web Workers terminate synchronously; Node `worker_threads` return a Promise. Adapters normalise to Promise. */
+	terminate(): Promise<unknown>;
 }
 
 /**
@@ -74,7 +75,7 @@ const PARSE_VALUE_SECTIONS_TIMEOUT_MS = 30_000;
  */
 export class WorkerExtensionManager<TCallerCtx = unknown> {
 	private readonly registry = new ProjectExtensionRegistry<WorkerRecord>({
-		dispose: terminate,
+		dispose: disposeRecord,
 	});
 	private readonly providers: Providers;
 	private readonly workerProvider: WorkerProvider;
@@ -276,16 +277,10 @@ export class WorkerExtensionManager<TCallerCtx = unknown> {
 					);
 					record.worker.postMessage({ kind: 'parse-value-sections-result', requestId, parsed });
 				} catch (error) {
-					const code =
-						error instanceof Squawk
-							? error.code
-							: ((error as { code?: string } | undefined)?.code ?? 'parse_value_sections_failed');
-					const messageText =
-						error instanceof Error ? error.message : ((error as { message?: string })?.message ?? 'unknown error');
 					record.worker.postMessage({
 						kind: 'parse-value-sections-error',
 						requestId,
-						error: { code, message: messageText },
+						error: serialiseErrorForWorker(error, 'parse_value_sections_failed'),
 					});
 				}
 				return;
@@ -353,7 +348,24 @@ function deserialiseWorkerError(error?: WorkerErrorEnvelope): Squawk {
 	});
 }
 
-function terminate(record: WorkerRecord): void {
+/**
+ * Inverse of `deserialiseWorkerError` for the host → worker direction —
+ * collapses anything thrown by a host callback into the small envelope
+ * the worker side expects on `parse-value-sections-error`. `Squawk`
+ * gets its `.code` preserved; anything else falls back to
+ * `defaultCode`.
+ */
+function serialiseErrorForWorker(error: unknown, defaultCode: string): WorkerErrorEnvelope {
+	if (error instanceof Squawk) return { code: error.code, message: error.message };
+	if (error instanceof Error) {
+		const code = (error as { code?: string }).code ?? defaultCode;
+		return { code, message: error.message };
+	}
+	const obj = (error ?? {}) as { code?: string; message?: string };
+	return { code: obj.code ?? defaultCode, message: obj.message ?? 'unknown error' };
+}
+
+function disposeRecord(record: WorkerRecord): void {
 	try {
 		record.unsubscribe();
 	} catch {

--- a/packages/runtime-shared/src/extensions/worker-manager.ts
+++ b/packages/runtime-shared/src/extensions/worker-manager.ts
@@ -1,0 +1,432 @@
+import type { Extension, ExtensionVariable, LoadedExtension } from '@beak/common/types/extensions';
+import Squawk from '@beak/common/utils/squawk';
+import ksuid from '@beak/ksuid';
+import type { ValueSections, Context as VariableContext } from '@getbeak/types/values';
+
+import { ExtensionManifests, type ParsedExtensionManifest } from './manifest';
+import { makeFullyQualifiedType, packageNameFromType, variableIdFromType } from './manifest-helpers';
+import { ProjectExtensionRegistry } from './registry-base';
+import type { Providers } from '../base';
+
+/**
+ * Per-package worker record held by the registry. The opaque worker handle
+ * is supplied by the host's `WorkerProvider`; the manager itself never
+ * touches platform primitives.
+ */
+interface WorkerRecord {
+	worker: UnifiedWorker;
+	unsubscribe: () => void;
+	loaded: LoadedExtension;
+	pendingCalls: Map<string, { resolve: (v: unknown) => void; reject: (e: unknown) => void }>;
+}
+
+/**
+ * Host adapter: spins up a worker that evaluates `WORKER_SOURCE`. The
+ * web shell wraps a `Worker` from a Blob URL; the Electron host wraps
+ * a `node:worker_threads` Worker with the runtime shim prepended.
+ */
+export interface WorkerProvider {
+	spawn(name: string): UnifiedWorker;
+}
+
+/**
+ * Minimal Worker shape that both Web Workers and `worker_threads`
+ * Workers satisfy after a thin adapter. Listener registrations return
+ * an unsubscribe function so the manager doesn't have to keep
+ * platform-specific references.
+ */
+export interface UnifiedWorker {
+	postMessage(message: unknown): void;
+	onMessage(listener: (message: unknown) => void): () => void;
+	onError(listener: (error: unknown) => void): () => void;
+	terminate(): void | Promise<unknown>;
+}
+
+/**
+ * Host callbacks the manager invokes when the worker reaches out for
+ * something the worker itself can't do — recursive variable parsing
+ * (which roundtrips back to the renderer over IPC) and structured
+ * logging (which lands in the host's logger).
+ */
+export interface WorkerManagerCallbacks<TCallerCtx = unknown> {
+	parseValueSections(
+		callerCtx: TCallerCtx,
+		varCtx: VariableContext,
+		parts: ValueSections,
+		recursiveDepth: number,
+	): Promise<string>;
+	log(packageName: string, level: string, message: string): void;
+}
+
+export interface WorkerExtensionManagerOptions<TCallerCtx = unknown> {
+	providers: Providers;
+	workerProvider: WorkerProvider;
+	callbacks: WorkerManagerCallbacks<TCallerCtx>;
+}
+
+const INIT_TIMEOUT_MS = 5_000;
+const CALL_TIMEOUT_MS = 30_000;
+const PARSE_VALUE_SECTIONS_TIMEOUT_MS = 30_000;
+
+/**
+ * Host-agnostic extension lifecycle + call routing. One worker per
+ * loaded extension; same surface every host already implemented before
+ * this consolidation. See ADR-0003.
+ */
+export class WorkerExtensionManager<TCallerCtx = unknown> {
+	private readonly registry = new ProjectExtensionRegistry<WorkerRecord>({
+		dispose: terminate,
+	});
+	private readonly providers: Providers;
+	private readonly workerProvider: WorkerProvider;
+	private readonly callbacks: WorkerManagerCallbacks<TCallerCtx>;
+	/**
+	 * Track in-flight parseValueSections calls keyed by the caller ctx
+	 * the request originated from. Currently used only to scope the
+	 * callback to the right host context; the manager itself doesn't
+	 * need to demultiplex by it.
+	 */
+	private callerCtxByWorker = new WeakMap<UnifiedWorker, TCallerCtx>();
+
+	constructor(opts: WorkerExtensionManagerOptions<TCallerCtx>) {
+		this.providers = opts.providers;
+		this.workerProvider = opts.workerProvider;
+		this.callbacks = opts.callbacks;
+	}
+
+	async resetProject(projectId: string): Promise<void> {
+		await this.registry.resetProject(projectId);
+	}
+
+	async load(
+		projectId: string,
+		extensionPath: string,
+		options: { validateScriptPath?: (scriptPath: string) => Promise<void> } = {},
+	): Promise<LoadedExtension> {
+		const manifests = new ExtensionManifests(this.providers);
+		const manifest = await manifests.parse(extensionPath, {
+			validateScriptPath: options.validateScriptPath,
+		});
+		const userSource = await readUserSource(this.providers, manifest);
+
+		const worker = this.workerProvider.spawn(`beak-ext:${manifest.packageName}`);
+
+		const record: WorkerRecord = {
+			worker,
+			unsubscribe: () => {},
+			loaded: {
+				status: 'loaded',
+				packageName: manifest.packageName,
+				version: manifest.version,
+				displayName: manifest.displayName,
+				description: manifest.description,
+				author: manifest.author,
+				homepage: manifest.homepage,
+				filePath: extensionPath,
+				apiVersion: 1,
+				variables: [],
+			},
+			pendingCalls: new Map(),
+		};
+
+		const metadata = await initWorker(worker, userSource, manifest.packageName);
+
+		record.loaded.variables = metadata.map(meta => ({
+			...meta,
+			type: makeFullyQualifiedType(manifest.packageName, meta.variableId),
+		}));
+
+		record.unsubscribe = this.attachListener(record);
+
+		await this.registry.insert(projectId, manifest.packageName, record);
+
+		return record.loaded;
+	}
+
+	async unload(projectId: string, packageName: string): Promise<void> {
+		await this.registry.unload(projectId, packageName);
+	}
+
+	list(projectId: string): Extension[] {
+		return this.registry.list(projectId);
+	}
+
+	/* ---- Variable invocation ------------------------------------------ */
+
+	async variableCreateDefaultPayload(
+		projectId: string,
+		type: string,
+		varCtx: VariableContext,
+		callerCtx: TCallerCtx,
+	): Promise<Record<string, unknown>> {
+		const { record, variableId } = this.resolve(projectId, type);
+		this.callerCtxByWorker.set(record.worker, callerCtx);
+		return (await this.call(record, [variableId, 'createDefaultPayload'], [varCtx])) as Record<string, unknown>;
+	}
+
+	async variableGetValue(
+		projectId: string,
+		type: string,
+		varCtx: VariableContext,
+		callerCtx: TCallerCtx,
+		payload: unknown,
+		recursiveDepth: number,
+	): Promise<string> {
+		const { record, variableId } = this.resolve(projectId, type);
+		this.callerCtxByWorker.set(record.worker, callerCtx);
+		return (await this.call(record, [variableId, 'getValue'], [varCtx, payload, recursiveDepth])) as string;
+	}
+
+	async variableGetAssetRef(
+		projectId: string,
+		type: string,
+		varCtx: VariableContext,
+		callerCtx: TCallerCtx,
+		payload: unknown,
+		recursiveDepth: number,
+	): Promise<{ sha256: string; size: number; contentType?: string } | null> {
+		const { record, variableId, meta } = this.resolve(projectId, type);
+		if (!meta.binary) return null;
+		this.callerCtxByWorker.set(record.worker, callerCtx);
+		return (await this.call(record, [variableId, 'getAssetRef'], [varCtx, payload, recursiveDepth])) as {
+			sha256: string;
+			size: number;
+			contentType?: string;
+		} | null;
+	}
+
+	async variableEditorCreateUI(
+		projectId: string,
+		type: string,
+		varCtx: VariableContext,
+		callerCtx: TCallerCtx,
+	): Promise<unknown> {
+		const { record, variableId } = this.resolve(projectId, type);
+		this.callerCtxByWorker.set(record.worker, callerCtx);
+		return await this.call(record, [variableId, 'editor', 'createUserInterface'], [varCtx]);
+	}
+
+	async variableEditorLoad(
+		projectId: string,
+		type: string,
+		varCtx: VariableContext,
+		callerCtx: TCallerCtx,
+		payload: unknown,
+	): Promise<unknown> {
+		const { record, variableId } = this.resolve(projectId, type);
+		this.callerCtxByWorker.set(record.worker, callerCtx);
+		return await this.call(record, [variableId, 'editor', 'load'], [varCtx, payload]);
+	}
+
+	async variableEditorSave(
+		projectId: string,
+		type: string,
+		varCtx: VariableContext,
+		callerCtx: TCallerCtx,
+		existingPayload: unknown,
+		state: unknown,
+	): Promise<unknown> {
+		const { record, variableId } = this.resolve(projectId, type);
+		this.callerCtxByWorker.set(record.worker, callerCtx);
+		return await this.call(record, [variableId, 'editor', 'save'], [varCtx, existingPayload, state]);
+	}
+
+	/* ---- Internals ----------------------------------------------------- */
+
+	private resolve(
+		projectId: string,
+		type: string,
+	): { record: WorkerRecord; variableId: string; meta: ExtensionVariable } {
+		const packageName = packageNameFromType(type);
+		const variableId = variableIdFromType(type);
+		const record = this.registry.byPackage(projectId, packageName);
+		const meta = record?.loaded.variables.find(v => v.variableId === variableId);
+
+		if (!record || !meta) throw new Squawk('unknown_registered_extension', { projectId, type });
+
+		return { record, variableId, meta };
+	}
+
+	private attachListener(record: WorkerRecord): () => void {
+		const unsubMessage = record.worker.onMessage(async raw => {
+			const message = raw as { kind: string; [k: string]: unknown };
+
+			if (message.kind === 'init-ok' || message.kind === 'init-error') return;
+
+			if (message.kind === 'result' || message.kind === 'error') {
+				const callId = message.callId as string;
+				const pending = record.pendingCalls.get(callId);
+				if (!pending) return;
+				record.pendingCalls.delete(callId);
+				if (message.kind === 'result') pending.resolve((message as unknown as { value: unknown }).value);
+				else pending.reject(deserialiseWorkerError(message.error as WorkerErrorEnvelope));
+				return;
+			}
+
+			if (message.kind === 'parse-value-sections') {
+				const requestId = message.requestId as string;
+				const ctx = message.ctx as VariableContext;
+				const parts = message.parts as ValueSections;
+
+				try {
+					const callerCtx = this.callerCtxByWorker.get(record.worker) as TCallerCtx;
+					const parsed = await withTimeout(
+						this.callbacks.parseValueSections(callerCtx, ctx, parts, 0),
+						PARSE_VALUE_SECTIONS_TIMEOUT_MS,
+						'parse_value_sections_timeout',
+					);
+					record.worker.postMessage({ kind: 'parse-value-sections-result', requestId, parsed });
+				} catch (error) {
+					const code =
+						error instanceof Squawk
+							? error.code
+							: (error as { code?: string } | undefined)?.code ?? 'parse_value_sections_failed';
+					const messageText =
+						error instanceof Error ? error.message : (error as { message?: string })?.message ?? 'unknown error';
+					record.worker.postMessage({
+						kind: 'parse-value-sections-error',
+						requestId,
+						error: { code, message: messageText },
+					});
+				}
+				return;
+			}
+
+			if (message.kind === 'log') {
+				const level = (message.level as string) || 'info';
+				const packageName = (message.packageName as string) || 'unknown';
+				const text = (message.message as string) || '';
+				this.callbacks.log(packageName, level, text);
+			}
+		});
+
+		const unsubError = record.worker.onError(error => {
+			// Surface to logger; in-flight calls still time out individually.
+			const messageText = error instanceof Error ? error.message : String(error);
+			this.callbacks.log(record.loaded.packageName, 'error', `worker error: ${messageText}`);
+		});
+
+		return () => {
+			unsubMessage();
+			unsubError();
+		};
+	}
+
+	private async call(record: WorkerRecord, path: string[], args: unknown[]): Promise<unknown> {
+		const callId = ksuid.generate('extcall').toString();
+
+		return await new Promise((resolve, reject) => {
+			const timer = setTimeout(() => {
+				record.pendingCalls.delete(callId);
+				reject(new Squawk('extension_call_timeout', { path, timeoutMs: CALL_TIMEOUT_MS }));
+			}, CALL_TIMEOUT_MS);
+
+			record.pendingCalls.set(callId, {
+				resolve: value => {
+					clearTimeout(timer);
+					resolve(value);
+				},
+				reject: error => {
+					clearTimeout(timer);
+					reject(error);
+				},
+			});
+
+			record.worker.postMessage({ kind: 'call', callId, path, args });
+		});
+	}
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Helpers                                                                   */
+/* -------------------------------------------------------------------------- */
+
+interface WorkerErrorEnvelope {
+	code?: string;
+	message?: string;
+	info?: unknown;
+}
+
+function deserialiseWorkerError(error?: WorkerErrorEnvelope): Squawk {
+	return new Squawk(error?.code ?? 'extension_runtime_error', {
+		message: error?.message ?? 'unknown error',
+		info: error?.info,
+	});
+}
+
+function terminate(record: WorkerRecord): void {
+	try {
+		record.unsubscribe();
+	} catch {
+		/* listener already detached */
+	}
+	try {
+		void record.worker.terminate();
+	} catch {
+		/* already terminated */
+	}
+
+	for (const pending of record.pendingCalls.values()) {
+		pending.reject(new Squawk('extension_terminated', {}));
+	}
+	record.pendingCalls.clear();
+}
+
+async function readUserSource(providers: Providers, manifest: ParsedExtensionManifest): Promise<string> {
+	const raw = await providers.node.fs.promises.readFile(manifest.scriptPath, 'utf8');
+	return typeof raw === 'string' ? raw : new TextDecoder().decode(raw as Uint8Array);
+}
+
+function initWorker(worker: UnifiedWorker, userSource: string, packageName: string): Promise<ExtensionVariable[]> {
+	return new Promise<ExtensionVariable[]>((resolve, reject) => {
+		const timer = setTimeout(() => {
+			cleanup();
+			void worker.terminate();
+			reject(new Squawk('extension_init_timeout', { packageName, timeoutMs: INIT_TIMEOUT_MS }));
+		}, INIT_TIMEOUT_MS);
+
+		const unsubscribe = worker.onMessage(raw => {
+			const data = raw as { kind: string };
+			if (data.kind === 'init-ok') {
+				cleanup();
+				resolve((data as unknown as { metadata: ExtensionVariable[] }).metadata);
+				return;
+			}
+			if (data.kind === 'init-error') {
+				cleanup();
+				const err = (data as unknown as { error: { code: string; message: string; info?: unknown } }).error;
+				void worker.terminate();
+				reject(
+					new Squawk(err.code, {
+						...((err.info as Record<string, unknown>) ?? {}),
+						message: err.message,
+						packageName,
+					}),
+				);
+			}
+		});
+
+		function cleanup() {
+			clearTimeout(timer);
+			unsubscribe();
+		}
+
+		worker.postMessage({ kind: 'init', userSource, packageName });
+	});
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, code: string): Promise<T> {
+	return await new Promise<T>((resolve, reject) => {
+		const timer = setTimeout(() => reject(new Squawk(code, { timeoutMs })), timeoutMs);
+		promise.then(
+			value => {
+				clearTimeout(timer);
+				resolve(value);
+			},
+			error => {
+				clearTimeout(timer);
+				reject(error);
+			},
+		);
+	});
+}

--- a/packages/runtime-shared/src/extensions/worker-manager.ts
+++ b/packages/runtime-shared/src/extensions/worker-manager.ts
@@ -295,9 +295,17 @@ export class WorkerExtensionManager<TCallerCtx = unknown> {
 		});
 
 		const unsubError = record.worker.onError(error => {
-			// Surface to logger; in-flight calls still time out individually.
+			// Node `worker_threads` exits after an uncaught exception; Web Workers
+			// keep running but in an undefined state. Either way, pending calls
+			// can't reliably resolve, so reject them immediately rather than let
+			// the user wait out the 30s call timeout. The record stays in the
+			// registry — the next variable invocation will surface either the
+			// real error from a fresh postMessage attempt or a clean timeout.
 			const messageText = error instanceof Error ? error.message : String(error);
 			this.callbacks.log(record.loaded.packageName, 'error', `worker error: ${messageText}`);
+			const reason = new Squawk('extension_worker_error', { packageName: record.loaded.packageName, message: messageText });
+			for (const pending of record.pendingCalls.values()) pending.reject(reason);
+			record.pendingCalls.clear();
 		});
 
 		return () => {

--- a/packages/runtime-shared/src/extensions/worker-manager.ts
+++ b/packages/runtime-shared/src/extensions/worker-manager.ts
@@ -2,11 +2,10 @@ import type { Extension, ExtensionVariable, LoadedExtension } from '@beak/common
 import Squawk from '@beak/common/utils/squawk';
 import ksuid from '@beak/ksuid';
 import type { ValueSections, Context as VariableContext } from '@getbeak/types/values';
-
+import type { Providers } from '../base';
 import { ExtensionManifests, type ParsedExtensionManifest } from './manifest';
 import { makeFullyQualifiedType, packageNameFromType, variableIdFromType } from './manifest-helpers';
 import { ProjectExtensionRegistry } from './registry-base';
-import type { Providers } from '../base';
 
 /**
  * Per-package worker record held by the registry. The opaque worker handle
@@ -280,9 +279,9 @@ export class WorkerExtensionManager<TCallerCtx = unknown> {
 					const code =
 						error instanceof Squawk
 							? error.code
-							: (error as { code?: string } | undefined)?.code ?? 'parse_value_sections_failed';
+							: ((error as { code?: string } | undefined)?.code ?? 'parse_value_sections_failed');
 					const messageText =
-						error instanceof Error ? error.message : (error as { message?: string })?.message ?? 'unknown error';
+						error instanceof Error ? error.message : ((error as { message?: string })?.message ?? 'unknown error');
 					record.worker.postMessage({
 						kind: 'parse-value-sections-error',
 						requestId,

--- a/packages/runtime-shared/src/extensions/worker-source.ts
+++ b/packages/runtime-shared/src/extensions/worker-source.ts
@@ -1,22 +1,47 @@
 /**
- * Source for the per-extension Web Worker. Built into a Blob URL at
- * `WebExtensionManager.load`-time so each extension gets a fresh worker.
+ * Source for the per-extension worker — runs identically in browser Web
+ * Workers and `node:worker_threads`. Built into a Blob URL (web) or eval'd
+ * inline (Node) at load-time, so each extension gets a fresh worker.
  *
- * Protocol (worker side):
+ * Cross-runtime contract:
+ *  - The script assumes the Web Worker API surface: `self`, top-level
+ *    `postMessage`, `self.addEventListener('message', ...)`.
+ *  - Node's `worker_threads` doesn't expose those; the Electron adapter
+ *    prepends the `WORKER_RUNTIME_NODE_SHIM` below before passing the
+ *    source to `new Worker(..., { eval: true })`.
+ *
+ * Wire protocol:
  *  - in:  `{ kind: 'init', userSource: string, packageName: string }`
- *  - out: `{ kind: 'init-ok', metadata: ExtensionVariable[] }` |
- *         `{ kind: 'init-error', error: { code, info } }`
+ *  - out: `{ kind: 'init-ok', metadata: ExtensionVariable[] }`
+ *         `{ kind: 'init-error', error: { code, message, info } }`
  *  - in:  `{ kind: 'call', callId, path: string[], args: unknown[] }`
- *  - out: `{ kind: 'result', callId, value }` | `{ kind: 'error', callId, error }`
+ *  - out: `{ kind: 'result', callId, value }`
+ *         `{ kind: 'error', callId, error }`
  *  - out: `{ kind: 'parse-value-sections', requestId, ctx, parts }`
- *  - in:  `{ kind: 'parse-value-sections-result', requestId, parsed }` |
+ *  - in:  `{ kind: 'parse-value-sections-result', requestId, parsed }`
  *         `{ kind: 'parse-value-sections-error', requestId, error }`
+ *  - out: `{ kind: 'log', packageName, level, message }`
  *
- * The worker has no DOM, no access to Beak's React state, and no
- * reference to the main thread's globals. It can still issue `fetch()`
- * and read IndexedDB on Beak's origin — that's the documented v1
- * trust model.
+ * Trust model: extensions are user-installed under a project's
+ * `extensions/` folder. Worker isolation provides V8-level memory
+ * separation but is not a defence against actively malicious code.
+ * See ADR-0003 for the full rationale.
  */
+
+/**
+ * Aliases the Web Worker globals onto Node's `parentPort` so the shared
+ * worker source can run unchanged under `node:worker_threads`. Prepended
+ * by the Electron WorkerProvider before `new Worker(source, { eval: true })`.
+ */
+export const WORKER_RUNTIME_NODE_SHIM = `
+const { parentPort } = require('node:worker_threads');
+globalThis.self = globalThis;
+globalThis.postMessage = parentPort.postMessage.bind(parentPort);
+globalThis.addEventListener = (type, fn) => {
+	if (type === 'message') parentPort.on('message', data => fn({ data }));
+};
+`;
+
 export const WORKER_SOURCE = `
 'use strict';
 

--- a/packages/runtime-shared/src/extensions/worker-source.ts
+++ b/packages/runtime-shared/src/extensions/worker-source.ts
@@ -30,15 +30,132 @@
 
 /**
  * Aliases the Web Worker globals onto Node's `parentPort` so the shared
- * worker source can run unchanged under `node:worker_threads`. Prepended
- * by the Electron WorkerProvider before `new Worker(source, { eval: true })`.
+ * worker source can run unchanged under `node:worker_threads`. Also
+ * installs `__beak_vm_evaluate` — a stricter evaluator that runs the
+ * user's extension code in a `vm.createContext` sandbox with an
+ * ECMAScript-only global. Prepended by the Electron WorkerProvider
+ * before `new Worker(source, { eval: true })`.
+ *
+ * The sandbox restores the isolation guarantee the previous
+ * `isolated-vm` implementation provided: no `process`, `Buffer`,
+ * `require`, dynamic `import()`, `fetch`, `console`, `setTimeout`, or
+ * any Node / Web platform API. Extensions get the language plus
+ * `extCtx` (the host bridge passed in as an argument) — full stop.
+ * See ADR-0003 §3 (Trust model).
  */
 export const WORKER_RUNTIME_NODE_SHIM = `
 const { parentPort } = require('node:worker_threads');
+const vm = require('node:vm');
+
 globalThis.self = globalThis;
 globalThis.postMessage = parentPort.postMessage.bind(parentPort);
 globalThis.addEventListener = (type, fn) => {
 	if (type === 'message') parentPort.on('message', data => fn({ data }));
+};
+
+const sandboxGlobals = Object.create(null);
+
+// Global values
+sandboxGlobals.undefined = undefined;
+sandboxGlobals.NaN = NaN;
+sandboxGlobals.Infinity = Infinity;
+
+// Global functions
+sandboxGlobals.parseInt = parseInt;
+sandboxGlobals.parseFloat = parseFloat;
+sandboxGlobals.isNaN = isNaN;
+sandboxGlobals.isFinite = isFinite;
+sandboxGlobals.encodeURI = encodeURI;
+sandboxGlobals.encodeURIComponent = encodeURIComponent;
+sandboxGlobals.decodeURI = decodeURI;
+sandboxGlobals.decodeURIComponent = decodeURIComponent;
+
+// Fundamental objects + Function constructor (sandboxed: code it
+// compiles inherits the same restricted globals via the vm context).
+sandboxGlobals.Object = Object;
+sandboxGlobals.Function = Function;
+sandboxGlobals.Boolean = Boolean;
+sandboxGlobals.Symbol = Symbol;
+
+// Errors
+sandboxGlobals.Error = Error;
+sandboxGlobals.TypeError = TypeError;
+sandboxGlobals.RangeError = RangeError;
+sandboxGlobals.SyntaxError = SyntaxError;
+sandboxGlobals.ReferenceError = ReferenceError;
+sandboxGlobals.EvalError = EvalError;
+sandboxGlobals.URIError = URIError;
+sandboxGlobals.AggregateError = AggregateError;
+
+// Numbers + math
+sandboxGlobals.Number = Number;
+sandboxGlobals.BigInt = BigInt;
+sandboxGlobals.Math = Math;
+sandboxGlobals.Date = Date;
+
+// Text
+sandboxGlobals.String = String;
+sandboxGlobals.RegExp = RegExp;
+
+// Collections
+sandboxGlobals.Array = Array;
+sandboxGlobals.Map = Map;
+sandboxGlobals.Set = Set;
+sandboxGlobals.WeakMap = WeakMap;
+sandboxGlobals.WeakSet = WeakSet;
+
+// Structured data
+sandboxGlobals.JSON = JSON;
+sandboxGlobals.ArrayBuffer = ArrayBuffer;
+sandboxGlobals.DataView = DataView;
+sandboxGlobals.Uint8Array = Uint8Array;
+sandboxGlobals.Uint8ClampedArray = Uint8ClampedArray;
+sandboxGlobals.Uint16Array = Uint16Array;
+sandboxGlobals.Uint32Array = Uint32Array;
+sandboxGlobals.Int8Array = Int8Array;
+sandboxGlobals.Int16Array = Int16Array;
+sandboxGlobals.Int32Array = Int32Array;
+sandboxGlobals.Float32Array = Float32Array;
+sandboxGlobals.Float64Array = Float64Array;
+sandboxGlobals.BigInt64Array = BigInt64Array;
+sandboxGlobals.BigUint64Array = BigUint64Array;
+
+// Control abstractions
+sandboxGlobals.Promise = Promise;
+
+// Reflection
+sandboxGlobals.Reflect = Reflect;
+sandboxGlobals.Proxy = Proxy;
+
+// Intl — locale-aware formatting; pure with no external state.
+sandboxGlobals.Intl = Intl;
+
+// Deliberately omitted (security): process, Buffer, require, globalThis-as-Node,
+// dynamic import(), fetch, crypto, console, setTimeout/setInterval, URL,
+// SharedArrayBuffer, Atomics, WebAssembly, eval (blocked via codeGeneration).
+
+const sandboxContext = vm.createContext(sandboxGlobals, {
+	name: 'beak-extension-sandbox',
+	// Disallow Function/eval from generating code from strings inside
+	// the sandbox. WASM is also off — extensions don't need it.
+	codeGeneration: { strings: false, wasm: false },
+});
+
+globalThis.__beak_vm_evaluate = function (userSource) {
+	const module = { exports: {} };
+	sandboxGlobals.module = module;
+	sandboxGlobals.exports = module.exports;
+	try {
+		vm.runInContext(
+			'(function (module, exports) {' + userSource + '\\n})(module, exports);',
+			sandboxContext,
+			{ filename: 'beak-extension.js' },
+		);
+	} finally {
+		delete sandboxGlobals.module;
+		delete sandboxGlobals.exports;
+	}
+	return module.exports && (module.exports.default !== undefined ? module.exports.default : module.exports);
 };
 `;
 
@@ -140,6 +257,15 @@ function validateAndBindExtension(raw, packageName) {
 }
 
 function evaluateUserSource(userSource) {
+	// In Node \`worker_threads\`, the runtime shim installs a vm-based
+	// evaluator that runs the user's extension code with an
+	// ECMAScript-only global (no Node APIs, no Web APIs). In a browser
+	// Web Worker the shim is absent and we fall back to \`new Function\` —
+	// the worker's globalThis still exposes Web APIs but cannot reach
+	// Beak's main thread state. See ADR-0003 §3.
+	if (typeof globalThis.__beak_vm_evaluate === 'function') {
+		return globalThis.__beak_vm_evaluate(userSource);
+	}
 	const module = { exports: {} };
 	const exports = module.exports;
 	const fn = new Function('module', 'exports', userSource);

--- a/packages/runtime-shared/src/extensions/worker-source.ts
+++ b/packages/runtime-shared/src/extensions/worker-source.ts
@@ -53,109 +53,50 @@ globalThis.addEventListener = (type, fn) => {
 	if (type === 'message') parentPort.on('message', data => fn({ data }));
 };
 
-const sandboxGlobals = Object.create(null);
-
-// Global values
-sandboxGlobals.undefined = undefined;
-sandboxGlobals.NaN = NaN;
-sandboxGlobals.Infinity = Infinity;
-
-// Global functions
-sandboxGlobals.parseInt = parseInt;
-sandboxGlobals.parseFloat = parseFloat;
-sandboxGlobals.isNaN = isNaN;
-sandboxGlobals.isFinite = isFinite;
-sandboxGlobals.encodeURI = encodeURI;
-sandboxGlobals.encodeURIComponent = encodeURIComponent;
-sandboxGlobals.decodeURI = decodeURI;
-sandboxGlobals.decodeURIComponent = decodeURIComponent;
-
-// Fundamental objects + Function constructor (sandboxed: code it
-// compiles inherits the same restricted globals via the vm context).
-sandboxGlobals.Object = Object;
-sandboxGlobals.Function = Function;
-sandboxGlobals.Boolean = Boolean;
-sandboxGlobals.Symbol = Symbol;
-
-// Errors
-sandboxGlobals.Error = Error;
-sandboxGlobals.TypeError = TypeError;
-sandboxGlobals.RangeError = RangeError;
-sandboxGlobals.SyntaxError = SyntaxError;
-sandboxGlobals.ReferenceError = ReferenceError;
-sandboxGlobals.EvalError = EvalError;
-sandboxGlobals.URIError = URIError;
-sandboxGlobals.AggregateError = AggregateError;
-
-// Numbers + math
-sandboxGlobals.Number = Number;
-sandboxGlobals.BigInt = BigInt;
-sandboxGlobals.Math = Math;
-sandboxGlobals.Date = Date;
-
-// Text
-sandboxGlobals.String = String;
-sandboxGlobals.RegExp = RegExp;
-
-// Collections
-sandboxGlobals.Array = Array;
-sandboxGlobals.Map = Map;
-sandboxGlobals.Set = Set;
-sandboxGlobals.WeakMap = WeakMap;
-sandboxGlobals.WeakSet = WeakSet;
-
-// Structured data
-sandboxGlobals.JSON = JSON;
-sandboxGlobals.ArrayBuffer = ArrayBuffer;
-sandboxGlobals.DataView = DataView;
-sandboxGlobals.Uint8Array = Uint8Array;
-sandboxGlobals.Uint8ClampedArray = Uint8ClampedArray;
-sandboxGlobals.Uint16Array = Uint16Array;
-sandboxGlobals.Uint32Array = Uint32Array;
-sandboxGlobals.Int8Array = Int8Array;
-sandboxGlobals.Int16Array = Int16Array;
-sandboxGlobals.Int32Array = Int32Array;
-sandboxGlobals.Float32Array = Float32Array;
-sandboxGlobals.Float64Array = Float64Array;
-sandboxGlobals.BigInt64Array = BigInt64Array;
-sandboxGlobals.BigUint64Array = BigUint64Array;
-
-// Control abstractions
-sandboxGlobals.Promise = Promise;
-
-// Reflection
-sandboxGlobals.Reflect = Reflect;
-sandboxGlobals.Proxy = Proxy;
-
-// Intl — locale-aware formatting; pure with no external state.
-sandboxGlobals.Intl = Intl;
-
-// Deliberately omitted (security): process, Buffer, require, globalThis-as-Node,
-// dynamic import(), fetch, crypto, console, setTimeout/setInterval, URL,
-// SharedArrayBuffer, Atomics, WebAssembly, eval (blocked via codeGeneration).
-
-const sandboxContext = vm.createContext(sandboxGlobals, {
+// Build the sandbox as a *fresh* vm context — the empty seed gives the
+// realm its own primordials (Object/Function/Array/…) so user code
+// can't walk \`anyValue.constructor.constructor\` up to the outer realm's
+// Function constructor and call it as a code-gen-permitted escape.
+// codeGeneration.{strings:false,wasm:false} blocks the in-context
+// Function constructor + eval + WebAssembly.compile.
+const sandboxContext = vm.createContext({}, {
 	name: 'beak-extension-sandbox',
-	// Disallow Function/eval from generating code from strings inside
-	// the sandbox. WASM is also off — extensions don't need it.
 	codeGeneration: { strings: false, wasm: false },
 });
 
+// Strip globals that vm hands us by default but extensions shouldn't reach:
+//   console        — extensions use extCtx.log
+//   Atomics + SharedArrayBuffer — memory-race surface, not needed
+//   WebAssembly    — wasm:false already blocks compile, drop the object too
+//   escape/unescape— legacy noise, no use case
+//   eval           — strings:false already blocks usage; drop the binding
+//   globalThis is left in place — it's the sandbox's own globalThis,
+//   not the outer one.
+const stripped = ['console', 'Atomics', 'SharedArrayBuffer', 'WebAssembly', 'escape', 'unescape', 'eval'];
+vm.runInContext(JSON.stringify(stripped) + '.forEach(k => { delete globalThis[k]; });', sandboxContext);
+
 globalThis.__beak_vm_evaluate = function (userSource) {
-	const module = { exports: {} };
-	sandboxGlobals.module = module;
-	sandboxGlobals.exports = module.exports;
+	// module and exports MUST be created inside the sandbox realm; passing
+	// outer-realm objects in lets the user walk
+	// \`module.constructor.constructor('return process')()\` to the outer
+	// Function and call it (codeGeneration restriction is per-context).
+	vm.runInContext('globalThis.module = { exports: {} }; globalThis.exports = module.exports;', sandboxContext);
 	try {
 		vm.runInContext(
 			'(function (module, exports) {' + userSource + '\\n})(module, exports);',
 			sandboxContext,
 			{ filename: 'beak-extension.js' },
 		);
+		// Read the user's exports out of the sandbox. The returned reference is
+		// a sandbox-realm object; cross-realm reads are fine, writes from the
+		// outer realm would mutate sandbox state (we don't do that).
+		return vm.runInContext(
+			'(module.exports && module.exports.default !== undefined) ? module.exports.default : module.exports',
+			sandboxContext,
+		);
 	} finally {
-		delete sandboxGlobals.module;
-		delete sandboxGlobals.exports;
+		vm.runInContext('delete globalThis.module; delete globalThis.exports;', sandboxContext);
 	}
-	return module.exports && (module.exports.default !== undefined ? module.exports.default : module.exports);
 };
 `;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,9 +104,6 @@ importers:
       fs-extra:
         specifier: ^11.3.5
         version: 11.3.5
-      isolated-vm:
-        specifier: ^6.1.2
-        version: 6.1.2
       isomorphic-git:
         specifier: ^1.37.6
         version: 1.37.6
@@ -4993,10 +4990,6 @@ packages:
     resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
     engines: {node: '>=20'}
 
-  isolated-vm@6.1.2:
-    resolution: {integrity: sha512-GGfsHqtlZiiurZaxB/3kY7LLAXR3sgzDul0fom4cSyBjx6ZbjpTrFWiH3z/nUfLJGJ8PIq9LQmQFiAxu24+I7A==}
-    engines: {node: '>=22.0.0'}
-
   isomorphic-git@1.37.6:
     resolution: {integrity: sha512-qr1NFCPsVTZ6YGqTXw0CzamnsHyH9QQ1OTEfeXIweSljRUMzuHFCJdUn0wc6OcjtTDns6knxjPb7N6LmJeftOA==}
     engines: {node: '>=14.17'}
@@ -5682,10 +5675,6 @@ packages:
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  node-gyp-build@4.8.4:
-    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
-    hasBin: true
 
   node-gyp@12.3.0:
     resolution: {integrity: sha512-QNcUWM+HgJplcPzBvFBZ9VXacyGZ4+VTOb80PwWR+TlVzoHbRKULNEzpRsnaoxG3Wzr7Qh7BYxGDU3CbKib2Yg==}
@@ -12680,10 +12669,6 @@ snapshots:
 
   isexe@4.0.0: {}
 
-  isolated-vm@6.1.2:
-    dependencies:
-      node-gyp-build: 4.8.4
-
   isomorphic-git@1.37.6:
     dependencies:
       async-lock: 1.4.1
@@ -13520,8 +13505,6 @@ snapshots:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
-
-  node-gyp-build@4.8.4: {}
 
   node-gyp@12.3.0:
     dependencies:


### PR DESCRIPTION
## Summary

Implements [ADR-0003](docs/adr/0003-unified-worker-extensions.md). Drops
`isolated-vm` entirely; both Electron and Web hosts now run extensions
in a Worker (Node `worker_threads` and Web Worker, respectively),
driven by one shared `WORKER_SOURCE` + `WorkerExtensionManager` in
`@beak/runtime-shared/extensions`.

Why now: PR #672 surfaced macOS notarization rejecting the unsigned
`.node` prebuilds + the stray `isolated-vm-X.Y.Z.tgz` shipping inside
`app.asar.unpacked`. The tactical fix was an `afterPack` prune; this
PR is the strategic fix — stop shipping native code for the extension
sandbox in the first place.

## Highlights

- **One source of truth** for the worker script —
  `packages/runtime-shared/src/extensions/worker-source.ts`. Web style
  (`self.addEventListener('message', …)`, top-level `postMessage`).
  A small shim aliases those onto `parentPort` for `worker_threads`.
- **`WorkerExtensionManager`** (new) handles every lifecycle bit that
  used to live twice: load, unload, resetProject, the call-router
  with timeouts, the recursive `parse-value-sections` bridge, error
  serialisation, log forwarding. Parameterised on a tiny
  `WorkerProvider` and two callbacks; both hosts subclass it.
- **Electron extension manager shrinks from 467 lines of `isolated-vm`
  glue to ~120 lines** of Worker adapter + IPC routing.
- **`isolated-vm` removed** from `apps-host/electron/package.json`,
  along with its `electron-rebuild -f -w isolated-vm` postinstall and
  the `external: ['…', 'isolated-vm']` esbuild entry. No more native
  rebuild on cold install, no more unsigned `.node` files in the macOS
  bundle.

## Sandbox tightness — matches `isolated-vm` on Electron

The first cut of this PR left Node `worker_threads` running extension
code with the worker's full `globalThis` in scope. That regressed the
isolation guarantee `isolated-vm` had given us. Fixed in `3119c01b`:

The Electron runtime shim now builds a `vm.createContext` with a
hand-curated ECMAScript-only global (Object/Array/Promise/Math/Date/
JSON/RegExp, the typed-array family, Reflect/Proxy/Intl, Error and
subclasses, parse/encode/decode helpers, plus `Function` — sandboxed
by the vm context). `codeGeneration: { strings: false, wasm: false }`
blocks `eval`, the Function-from-string constructor, and dynamic WASM.

Deliberately omitted (security): `process`, `Buffer`, `require`,
dynamic `import()`, `fetch`, `console`, `setTimeout`/`setInterval`,
`URL`, `SharedArrayBuffer`, `Atomics`, `WebAssembly`. Extensions get
the language plus `extCtx` — full stop. Identical posture to the old
`isolated-vm` setup.

Web Workers don't have a `vm`-style context API, so the web side
remains at the looser baseline (`new Function` inside the worker's
globalThis). Tightening it properly needs Realms (Stage 3, not widely
shipped) or iframe sandboxes — out of scope for this PR; tracked as
follow-up in ADR-0003 §3.

Memory isolation in both runtimes is identical to `isolated-vm` —
each worker is its own V8 isolate with its own heap.

## SDK contract

`@getbeak/extension-sdk` is unchanged. Extensions written against
`defineExtension({ apiVersion: 1, variables: [...] })` keep working;
the validation shape inside the worker is identical.

## Test plan

- [x] `pnpm lint` exit 0
- [x] `pnpm typecheck:apps-host` exit 0 across every workspace
- [x] `pnpm build` exit 0 across every workspace
- [ ] Load an extension in Electron, exercise `getValue` + recursive
  `parseValueSections` — needs hands-on (no automated extension test
  fixture in the repo yet)
- [ ] Same in the web host
- [ ] In Electron, confirm an extension calling `process` / `require`
  / `import('node:fs')` / `fetch` throws ReferenceError or fails
  cleanly (the `vm` context should block all of these)
- [ ] Confirm macOS notarization no longer trips on unsigned
  `isolated-vm` artefacts (CI will tell us)